### PR TITLE
Allow Radius 0 in Demo

### DIFF
--- a/src/DotRecast.Recast.Demo/UI/RcSettingsView.cs
+++ b/src/DotRecast.Recast.Demo/UI/RcSettingsView.cs
@@ -123,7 +123,7 @@ public class RcSettingsView : IRcView
         ImGui.Text("Agent");
         ImGui.Separator();
         ImGui.SliderFloat("Height", ref settings.agentHeight, 0.1f, 5f, "%.1f");
-        ImGui.SliderFloat("Radius", ref settings.agentRadius, 0.1f, 5f, "%.1f");
+        ImGui.SliderFloat("Radius", ref settings.agentRadius, 0.0f, 5f, "%.1f");
         ImGui.SliderFloat("Max Climb", ref settings.agentMaxClimb, 0.1f, 5f, "%.1f");
         ImGui.SliderFloat("Max Slope", ref settings.agentMaxSlope, 1f, 90f, "%.0f");
         ImGui.SliderFloat("Max Acceleration", ref settings.agentMaxAcceleration, 8f, 999f, "%.1f");


### PR DESCRIPTION
Recast C++ demo allows radius 0 and I have a use case for it. I think it should be allowed