### PR TITLE
Fix updated struct version

### DIFF
--- a/src/DotRecast.Detour.Extras/Unity/Astar/Meta.cs
+++ b/src/DotRecast.Detour.Extras/Unity/Astar/Meta.cs
@@ -25,7 +25,7 @@ namespace DotRecast.Detour.Extras.Unity.Astar
     {
         public const string TYPENAME_RECAST_GRAPH = "Pathfinding.RecastGraph";
         public const string MIN_SUPPORTED_VERSION = "4.0.6";
-        public const string UPDATED_STRUCT_VERSION = "4.1.16";
+        public const string UPDATED_STRUCT_VERSION = "4.1.0";
         public static readonly Regex VERSION_PATTERN = new Regex(@"(\d+)\.(\d+)\.(\d+)");
         public string version { get; set; }
         public int graphs { get; set; }


### PR DESCRIPTION
I went through all of the version of astarpathfindingproject and found 4.1.0 to be the correct version