### PR TITLE
CyclicBuffer optimizations

### DIFF
--- a/src/DotRecast.Core/Buffers/RcCyclicBuffers.cs
+++ b/src/DotRecast.Core/Buffers/RcCyclicBuffers.cs
@@ -7,7 +7,11 @@
             long sum = 0;
             checked
             {
-                source.ForEach(x => sum += x);
+                // NOTE: SIMD would be nice here
+                foreach (var x in source)
+                {
+                    sum += x;
+                }
             }
 
             return sum;
@@ -27,11 +31,11 @@
                 return 0;
             
             long minValue = long.MaxValue;
-            source.ForEach(x =>
+            foreach (var x in source)
             {
                 if (x < minValue)
                     minValue = x;
-            });
+            }
 
             return minValue;
         }
@@ -42,11 +46,11 @@
                 return 0;
             
             long maxValue = long.MinValue;
-            source.ForEach(x =>
+            foreach (var x in source)
             {
                 if (x > maxValue)
                     maxValue = x;
-            });
+            }
 
             return maxValue;
         }

--- a/test/DotRecast.Core.Test/RcCyclicBufferTest.cs
+++ b/test/DotRecast.Core.Test/RcCyclicBufferTest.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using DotRecast.Core.Buffers;
+using DotRecast.Core.Collections;
 using NUnit.Framework;
 
 namespace DotRecast.Core.Test;
@@ -39,11 +40,11 @@ public class RcCyclicBufferTests
         var buffer = new RcCyclicBuffer<int>(5, new[] { 0, 1, 2, 3 });
 
         int x = 0;
-        buffer.ForEach(item =>
+        foreach (var item in buffer)
         {
             Assert.That(item, Is.EqualTo(x));
             x++;
-        });
+        }
     }
 
     [Test]
@@ -288,6 +289,42 @@ public class RcCyclicBufferTests
         for (int i = 0; i < 5; i++)
         {
             Assert.That(buffer[i], Is.EqualTo(i));
+        }
+    }
+    
+    [Test]
+    public void RcCyclicBuffer_RegularForEachWorks()
+    {
+        var refValues = new[] { 4, 3, 2, 1, 0 };
+        var buffer = new RcCyclicBuffer<int>(5, refValues);
+
+        var index = 0;
+        foreach (var element in buffer)
+        {
+            Assert.That(element, Is.EqualTo(refValues[index++]));
+        }
+    }
+    
+    [Test]
+    public void RcCyclicBuffer_EnumeratorWorks()
+    {
+        var refValues = new[] { 4, 3, 2, 1, 0 };
+        var buffer = new RcCyclicBuffer<int>(5, refValues);
+
+        var index = 0;
+        var enumerator = buffer.GetEnumerator();
+        enumerator.Reset();
+        while (enumerator.MoveNext())
+        {
+            Assert.That(enumerator.Current, Is.EqualTo(refValues[index++]));
+        }
+        
+        // Ensure Reset works properly
+        index = 0;
+        enumerator.Reset();
+        while (enumerator.MoveNext())
+        {
+            Assert.That(enumerator.Current, Is.EqualTo(refValues[index++]));
         }
     }
 }


### PR DESCRIPTION
1) Ditch `ForEach(Action<T>)` because it allocates
2) Implement Enumerator to support `foreach` keyword
3) Implement `IEnumerable<T>` to support Linq (don't use it though)
4) In `ToArray()` copy the whole block of memory (or rather two) instead of copying one by one
