### PR TITLE
Optimization: reduce number of allocations on hot path in RcRasterizations.DividePoly

### DIFF
--- a/src/DotRecast.Recast/RcRasterizations.cs
+++ b/src/DotRecast.Recast/RcRasterizations.cs
@@ -156,7 +156,7 @@ namespace DotRecast.Recast
             float axisOffset, int axis)
         {
             // How far positive or negative away from the separating axis is each vertex.
-            float[] inVertAxisDelta = new float[12];
+            Span<float> inVertAxisDelta = stackalloc float[12];
             for (int inVert = 0; inVert < inVertsCount; ++inVert)
             {
                 inVertAxisDelta[inVert] = axisOffset - inVerts[inVertsOffset + inVert * 3 + axis];


### PR DESCRIPTION
Before:
![image](https://github.com/ikpil/DotRecast/assets/20607474/023b973a-a5c3-4c78-89e0-243995287c40)

After:
![image](https://github.com/ikpil/DotRecast/assets/20607474/b83d3bb0-6707-4afe-bd01-53c4564ed8c4)
