### PR TITLE
Optimization (breaking): pool RcSpans.

### DIFF
--- a/src/DotRecast.Recast/RcCompacts.cs
+++ b/src/DotRecast.Recast/RcCompacts.cs
@@ -91,26 +91,25 @@ namespace DotRecast.Recast
             int numColumns = xSize * zSize;
             for (int columnIndex = 0; columnIndex < numColumns; ++columnIndex)
             {
-                RcSpan span = heightfield.spans[columnIndex];
+                uint spanIndex = heightfield.spans[columnIndex];
 
                 // If there are no spans at this cell, just leave the data to index=0, count=0.
-                if (span == null)
-                    continue;
-
                 int tmpIdx = currentCellIndex;
                 int tmpCount = 0;
-                for (; span != null; span = span.next)
+                while (spanIndex != 0)
                 {
+                    ref var span = ref heightfield.Span(spanIndex);
                     if (span.area != RC_NULL_AREA)
                     {
                         int bot = span.smax;
-                        int top = span.next != null ? (int)span.next.smin : MAX_HEIGHT;
+                        int top = span.next != 0 ? heightfield.Span(span.next).smin : MAX_HEIGHT;
                         tempSpans[currentCellIndex].y = Math.Clamp(bot, 0, MAX_HEIGHT);
                         tempSpans[currentCellIndex].h = Math.Clamp(top - bot, 0, MAX_HEIGHT);
                         compactHeightfield.areas[currentCellIndex] = span.area;
                         currentCellIndex++;
                         tmpCount++;
                     }
+                    spanIndex = span.next;
                 }
 
                 compactHeightfield.cells[columnIndex] = new RcCompactCell(tmpIdx, tmpCount);
@@ -191,9 +190,9 @@ namespace DotRecast.Recast
             int spanCount = 0;
             for (int columnIndex = 0; columnIndex < numCols; ++columnIndex)
             {
-                for (RcSpan span = heightfield.spans[columnIndex]; span != null; span = span.next)
+                for (uint span = heightfield.spans[columnIndex]; span != 0; span = heightfield.Span(span).next)
                 {
-                    if (span.area != RC_NULL_AREA)
+                    if (heightfield.Span(span).area != RC_NULL_AREA)
                     {
                         spanCount++;
                     }

--- a/src/DotRecast.Recast/RcHeightfield.cs
+++ b/src/DotRecast.Recast/RcHeightfield.cs
@@ -44,7 +44,10 @@ namespace DotRecast.Recast
         public readonly float ch;
 
         /** Heightfield of spans (width*height). */
-        public readonly RcSpan[] spans;
+        public readonly uint[] spans;
+
+        /** Actual span storage. */
+        public readonly RcSpanPool spanPool;
 
         /** Border size in cell units */
         public readonly int borderSize;
@@ -58,7 +61,10 @@ namespace DotRecast.Recast
             this.cs = cs;
             this.ch = ch;
             this.borderSize = borderSize;
-            spans = new RcSpan[width * height];
+            spans = new uint[width * height];
+            spanPool = new RcSpanPool();
         }
+
+        public ref RcSpan Span(uint index) => ref spanPool.Span(index);
     }
 }

--- a/src/DotRecast.Recast/RcSpan.cs
+++ b/src/DotRecast.Recast/RcSpan.cs
@@ -18,10 +18,12 @@ freely, subject to the following restrictions:
 3. This notice may not be removed or altered from any source distribution.
 */
 
+using System;
+
 namespace DotRecast.Recast
 {
     /** Represents a span in a heightfield. */
-    public class RcSpan
+    public struct RcSpan
     {
         /** The lower limit of the span. [Limit: &lt; smax] */
         public int smin;
@@ -32,7 +34,53 @@ namespace DotRecast.Recast
         /** The area id assigned to the span. */
         public int area;
 
-        /** The next span higher up in column. */
-        public RcSpan next;
+        /** The index next span higher up in column. For span in the free list, this is the index of the next free span. */
+        public uint next;
+    }
+
+    /** A pool of spans. Index 0 is reserved to mean 'null'. */
+    public class RcSpanPool
+    {
+        private RcSpan[] storage = new RcSpan[64 * 1024];
+        private uint firstUnalloc = 1; // storage element with index >= this is not initialized
+
+        public RcSpanPool()
+        {
+            storage[0].next = firstUnalloc;
+        }
+
+        public ref RcSpan Span(uint index) => ref storage[index];
+
+        public uint Alloc()
+        {
+            var index = storage[0].next;
+            if (index < firstUnalloc)
+            {
+                // get span from the free list
+                storage[0].next = storage[index].next;
+                storage[index].next = 0;
+                return index;
+            }
+
+            // free list is empty
+            if (storage.Length == firstUnalloc)
+            {
+                // and storage is full => grow
+                var oldStorage = storage;
+                storage = new RcSpan[oldStorage.Length * 2];
+                Array.Copy(oldStorage, storage, oldStorage.Length);
+            }
+
+            // index == firstUnalloc => storage[index] == 0 (never initialized)
+            storage[0].next = ++firstUnalloc;
+            return index;
+        }
+
+        public void Free(uint index)
+        {
+            // push span to the head of the free list
+            storage[index].next = storage[0].next;
+            storage[0].next = index;
+        }
     }
 }


### PR DESCRIPTION
Before (using changes from my other PR):
![image](https://github.com/ikpil/DotRecast/assets/20607474/34b36093-8d11-4010-a71b-fbed2a87bf41)

After:
![image](https://github.com/ikpil/DotRecast/assets/20607474/f4ae0418-2171-4c49-bf98-cb4a1a17bd30)
