### PR TITLE
[Upstream] fix: Fix raycast shortcuts (@Sarofc)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 - Nothing
 
 ### Fixed
-- Nothing
+- Fix raycast shortcuts ([@Sarofc](https://github.com/Sarofc)) [#72](https://github.com/ikpil/DotRecast/issues/72)
 
 ### Changed
 - Changed data structure of 'neis' from List<byte> to byte[] for optimized memory usage and improved access speed in `DtLayerMonotoneRegion`

--- a/src/DotRecast.Detour/DtNavMeshQuery.cs
+++ b/src/DotRecast.Detour/DtNavMeshQuery.cs
@@ -980,7 +980,7 @@ namespace DotRecast.Detour
                             DtRaycastOptions.DT_RAYCAST_USE_COSTS, ref rayHit, grandpaRef);
                         if (rayStatus.Succeeded())
                         {
-                            foundShortCut = rayHit.t >= 1.0f;
+                            foundShortCut = rayHit.t >= 1.0f && rayHit.path[^1] == neighbourRef;
                             if (foundShortCut)
                             {
                                 shortcut = new List<long>(rayHit.path);
@@ -1296,7 +1296,7 @@ namespace DotRecast.Detour
                             DtRaycastOptions.DT_RAYCAST_USE_COSTS, ref rayHit, grandpaRef);
                         if (status.Succeeded())
                         {
-                            foundShortCut = rayHit.t >= 1.0f;
+                            foundShortCut = rayHit.t >= 1.0f && rayHit.path[^1] == neighbourRef;
                             if (foundShortCut)
                             {
                                 shortcut = new List<long>(rayHit.path);
@@ -3143,7 +3143,7 @@ namespace DotRecast.Detour
             int maxSegments)
         {
             segmentCount = 0;
-            
+
             DtStatus status = m_nav.GetTileAndPolyByRef(refs, out var tile, out var poly);
             if (status.Failed())
             {

--- a/src/DotRecast.Recast.Toolset/Tools/RcTestNavMeshTool.cs
+++ b/src/DotRecast.Recast.Toolset/Tools/RcTestNavMeshTool.cs
@@ -272,7 +272,7 @@ namespace DotRecast.Recast.Toolset.Tools
             // results ...
             polys = path;
 
-            if (t > 1)
+            if (t >= 1)
             {
                 // No hit
                 hitPos = endPos;


### PR DESCRIPTION
Raycast is performed in 2d and it might report reaching the given position even if the Y coordinate is different than the target. Therefore, it is necessary to check what poly is actually hit by raycast before taking a shortcut.

- https://github.com/recast4j/recast4j/issues/196
- https://github.com/recast4j/recast4j/pull/197
- https://github.com/ikpil/DotRecast/issues/72