### PR TITLE
DtNavMeshQuery allocation fixes

### DIFF
--- a/src/DotRecast.Core/Buffers/RcRentedArray.cs
+++ b/src/DotRecast.Core/Buffers/RcRentedArray.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Buffers;
 using System.Runtime.CompilerServices;
 
@@ -41,6 +41,11 @@ namespace DotRecast.Core.Buffers
         public T[] AsArray()
         {
             return _array;
+        }
+
+        public Span<T> AsSpan()
+        {
+            return new Span<T>(_array, 0, Length);
         }
 
 

--- a/src/DotRecast.Detour/DtCallbackPolyQuery.cs
+++ b/src/DotRecast.Detour/DtCallbackPolyQuery.cs
@@ -11,7 +11,7 @@ namespace DotRecast.Detour
             _callback = callback;
         }
 
-        public void Process(DtMeshTile tile, DtPoly[] poly, Span<long> refs, int count)
+        public void Process(DtMeshTile tile, Span<DtPoly> poly, Span<long> refs, int count)
         {
             for (int i = 0; i < count; ++i)
             {

--- a/src/DotRecast.Detour/DtCollectPolysQuery.cs
+++ b/src/DotRecast.Detour/DtCollectPolysQuery.cs
@@ -26,7 +26,7 @@ namespace DotRecast.Detour
             return m_overflow;
         }
 
-        public void Process(DtMeshTile tile, DtPoly[] poly, Span<long> refs, int count)
+        public void Process(DtMeshTile tile, Span<DtPoly> poly, Span<long> refs, int count)
         {
             int numLeft = m_maxPolys - m_numCollected;
             int toCopy = count;

--- a/src/DotRecast.Detour/DtFindNearestPolyQuery.cs
+++ b/src/DotRecast.Detour/DtFindNearestPolyQuery.cs
@@ -20,7 +20,7 @@ namespace DotRecast.Detour
             _nearestPoint = center;
         }
 
-        public void Process(DtMeshTile tile, DtPoly[] poly, Span<long> refs, int count)
+        public void Process(DtMeshTile tile, Span<DtPoly> poly, Span<long> refs, int count)
         {
             for (int i = 0; i < count; ++i)
             {

--- a/src/DotRecast.Detour/DtNavMesh.cs
+++ b/src/DotRecast.Detour/DtNavMesh.cs
@@ -1366,6 +1366,11 @@ namespace DotRecast.Detour
 
         public int GetTilesAt(int x, int y, DtMeshTile[] tiles, int maxTiles)
         {
+            return GetTilesAt(x, y, (Span<DtMeshTile>)tiles, maxTiles);
+        }
+
+        public int GetTilesAt(int x, int y, Span<DtMeshTile> tiles, int maxTiles)
+        {
             int n = 0;
 
             // Find tile based on hash.

--- a/src/DotRecast.Detour/DtNavMeshQuery.cs
+++ b/src/DotRecast.Detour/DtNavMeshQuery.cs
@@ -788,7 +788,8 @@ namespace DotRecast.Detour
             m_nav.CalcTileLoc(bmax, out var maxx, out var maxy);
 
             const int MAX_NEIS = 32;
-            DtMeshTile[] neis = new DtMeshTile[MAX_NEIS];
+            using RcRentedArray<DtMeshTile> neisRent = RcRentedArray.Rent<DtMeshTile>(MAX_NEIS);
+            Span<DtMeshTile> neis = neisRent.AsSpan();
 
             for (int y = miny; y <= maxy; ++y)
             {

--- a/src/DotRecast.Detour/DtNavMeshQuery.cs
+++ b/src/DotRecast.Detour/DtNavMeshQuery.cs
@@ -21,6 +21,7 @@ freely, subject to the following restrictions:
 using System;
 using System.Collections.Generic;
 using DotRecast.Core;
+using DotRecast.Core.Buffers;
 using DotRecast.Core.Numerics;
 
 namespace DotRecast.Detour
@@ -597,7 +598,8 @@ namespace DotRecast.Detour
         {
             const int batchSize = 32;
             Span<long> polyRefs = stackalloc long[batchSize];
-            DtPoly[] polys = new DtPoly[batchSize];
+            using RcRentedArray<DtPoly> polysRent = RcRentedArray.Rent<DtPoly>(batchSize);
+            Span<DtPoly> polys = new Span<DtPoly>(polysRent.AsArray(), 0, batchSize);
             int n = 0;
 
             if (tile.data.bvTree != null)

--- a/src/DotRecast.Detour/DtNavMeshQuery.cs
+++ b/src/DotRecast.Detour/DtNavMeshQuery.cs
@@ -599,7 +599,7 @@ namespace DotRecast.Detour
             const int batchSize = 32;
             Span<long> polyRefs = stackalloc long[batchSize];
             using RcRentedArray<DtPoly> polysRent = RcRentedArray.Rent<DtPoly>(batchSize);
-            Span<DtPoly> polys = new Span<DtPoly>(polysRent.AsArray(), 0, batchSize);
+            Span<DtPoly> polys = polysRent.AsSpan();
             int n = 0;
 
             if (tile.data.bvTree != null)

--- a/src/DotRecast.Detour/IDtPolyQuery.cs
+++ b/src/DotRecast.Detour/IDtPolyQuery.cs
@@ -9,6 +9,6 @@ namespace DotRecast.Detour
     {
         /// Called for each batch of unique polygons touched by the search area in dtNavMeshQuery::queryPolygons.
         /// This can be called multiple times for a single query.
-        void Process(DtMeshTile tile, DtPoly[] poly, Span<long> refs, int count);
+        void Process(DtMeshTile tile, Span<DtPoly> poly, Span<long> refs, int count);
     }
 }


### PR DESCRIPTION
I replaced array allocation with rented buffer. However there's still an issue. RcRentedArray is a class. So making new instance will allocate memory in heap. Making it a struct will solve the issue. I didn't because it will break tests.

Instances of IDtPolyQuery are also allocating every frame. Would be better to turn them structs. Then make all methods accepting queries to be generic. It is more risky change.