### PR TITLE
DtNodePool caching

### DIFF
--- a/src/DotRecast.Core/Buffers/RcObjectPool.cs
+++ b/src/DotRecast.Core/Buffers/RcObjectPool.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+
+namespace DotRecast.Core.Buffers
+{
+    // This implementation is thread unsafe
+    public class RcObjectPool<T> where T : class
+    {
+        private readonly Queue<T> _items = new Queue<T>();
+        private readonly Func<T> _createFunc;
+
+        public RcObjectPool(Func<T> createFunc)
+        {
+            _createFunc = createFunc;
+        }
+
+        public T Get()
+        {
+            if (_items.TryDequeue(out var result))
+                return result;
+
+            return _createFunc();
+        }
+
+        public void Return(T obj)
+        {
+            _items.Enqueue(obj);
+        }
+    }
+}

--- a/src/DotRecast.Detour.Crowd/DtCrowd.cs
+++ b/src/DotRecast.Detour.Crowd/DtCrowd.cs
@@ -129,7 +129,7 @@ namespace DotRecast.Detour.Crowd
         private readonly DtObstacleAvoidanceParams[] _obstacleQueryParams;
         private readonly DtObstacleAvoidanceQuery _obstacleQuery;
 
-        private DtProximityGrid _grid;
+        private readonly DtProximityGrid _grid;
 
         private int _maxPathResult;
         private readonly RcVec3f _agentPlacementHalfExtents;
@@ -174,6 +174,7 @@ namespace DotRecast.Detour.Crowd
             _agentIdx = new RcAtomicInteger(0);
             _agents = new Dictionary<int, DtCrowdAgent>();
             _activeAgents = new List<DtCrowdAgent>();
+            _grid = new DtProximityGrid(_config.maxAgentRadius * 3);
 
             // The navQuery is mostly used for local searches, no need for large node pool.
             SetNavMesh(nav);
@@ -864,7 +865,7 @@ namespace DotRecast.Detour.Crowd
         {
             using var timer = _telemetry.ScopedTimer(DtCrowdTimerLabel.BuildProximityGrid);
 
-            _grid = new DtProximityGrid(_config.maxAgentRadius * 3);
+            _grid.Clear();
 
             for (var i = 0; i < agents.Count; i++)
             {

--- a/src/DotRecast.Detour.Crowd/DtProximityGrid.cs
+++ b/src/DotRecast.Detour.Crowd/DtProximityGrid.cs
@@ -80,6 +80,7 @@ namespace DotRecast.Detour.Crowd
                     if (!_items.TryGetValue(key, out var ids))
                     {
                         ids = _listPool.Get();
+                        ids.Clear();
                         _items.Add(key, ids);
                     }
 


### PR DESCRIPTION
Make sure we reuse objects as much as possible in game loop. This patch will prevent allocating List<T> and arrays when lists resize.