### PR TITLE
feat(debug-draw): add an option to render meshes in a left-handed coordinate system

### DIFF
--- a/src/DotRecast.Recast.Demo/Draw/DebugDraw.cs
+++ b/src/DotRecast.Recast.Demo/Draw/DebugDraw.cs
@@ -30,6 +30,8 @@ public class DebugDraw
     private readonly GLCheckerTexture g_tex;
     private readonly ModernOpenGLDraw openGlDraw;
 
+    private bool _renderAsLeftHanded = false;
+
     public DebugDraw(GL gl)
     {
         g_tex = new GLCheckerTexture(gl);
@@ -649,6 +651,14 @@ public class DebugDraw
         t.M42 = -cameraPos.Y;
         t.M43 = -cameraPos.Z;
         _viewMatrix = RcMatrix4x4f.Mul(ref r, ref t);
+
+        if (_renderAsLeftHanded)
+        {
+            _viewMatrix.M31 = -_viewMatrix.M31;
+            _viewMatrix.M32 = -_viewMatrix.M32;
+            _viewMatrix.M33 = -_viewMatrix.M33;
+        }
+
         GetOpenGlDraw().ViewMatrix(ref _viewMatrix);
         UpdateFrustum();
         return _viewMatrix;
@@ -749,5 +759,11 @@ public class DebugDraw
     public bool FrustumTest(RcVec3f bmin, RcVec3f bmax)
     {
         return FrustumTest(stackalloc float[] { bmin.X, bmin.Y, bmin.Z, bmax.X, bmax.Y, bmax.Z });
+    }
+
+    public void SetAsRenderLeftHanded(bool renderAsLeftHanded)
+    {
+        _renderAsLeftHanded = renderAsLeftHanded;
+        GetOpenGlDraw().SetWindingOrder(_renderAsLeftHanded ? GLEnum.CW : GLEnum.Ccw);
     }
 }

--- a/src/DotRecast.Recast.Demo/Draw/ModernOpenGLDraw.cs
+++ b/src/DotRecast.Recast.Demo/Draw/ModernOpenGLDraw.cs
@@ -29,6 +29,7 @@ public class ModernOpenGLDraw : IOpenGLDraw
     private int uniformFog;
     private int uniformFogStart;
     private int uniformFogEnd;
+    private GLEnum _windingOrder = GLEnum.Ccw;
 
     public ModernOpenGLDraw(GL gl)
     {
@@ -172,6 +173,7 @@ void main(){{
         _gl.Disable(GLEnum.Texture2D);
         _gl.Enable(GLEnum.DepthTest);
         _gl.Enable(GLEnum.CullFace);
+        _gl.FrontFace(_windingOrder);
     }
 
     public void Begin(DebugDrawPrimitives prim, float size)
@@ -329,5 +331,10 @@ void main(){{
     public void Fog(bool state)
     {
         fogEnabled = state;
+    }
+
+    public void SetWindingOrder(GLEnum windingOrder)
+    {
+        _windingOrder = windingOrder;
     }
 }

--- a/src/DotRecast.Recast.Demo/RecastDemo.cs
+++ b/src/DotRecast.Recast.Demo/RecastDemo.cs
@@ -153,7 +153,7 @@ public class RecastDemo : IRecastDemoChannel
         var modelviewMatrix = dd.ViewMatrix(cameraPos, cameraEulers);
         cameraPos.X += scrollZoom * 2.0f * modelviewMatrix.M13;
         cameraPos.Y += scrollZoom * 2.0f * modelviewMatrix.M23;
-        cameraPos.Z += scrollZoom * 2.0f * modelviewMatrix.M33;
+        cameraPos.Z += scrollZoom * 2.0f * modelviewMatrix.M33 * (settingsView.RenderAsLeftHanded ? -1 : 1);
         scrollZoom = 0;
     }
 
@@ -180,11 +180,11 @@ public class RecastDemo : IRecastDemoChannel
 
             cameraPos.X -= 0.1f * dx * modelviewMatrix.M11;
             cameraPos.Y -= 0.1f * dx * modelviewMatrix.M21;
-            cameraPos.Z -= 0.1f * dx * modelviewMatrix.M31;
+            cameraPos.Z -= 0.1f * dx * modelviewMatrix.M31 * (settingsView.RenderAsLeftHanded ? -1 : 1);
 
             cameraPos.X += 0.1f * dy * modelviewMatrix.M12;
             cameraPos.Y += 0.1f * dy * modelviewMatrix.M22;
-            cameraPos.Z += 0.1f * dy * modelviewMatrix.M32;
+            cameraPos.Z += 0.1f * dy * modelviewMatrix.M32 * (settingsView.RenderAsLeftHanded ? -1 : 1);
             if (dx * dx + dy * dy > 3 * 3)
             {
                 movedDuringPan = true;
@@ -479,6 +479,8 @@ public class RecastDemo : IRecastDemoChannel
             settingsView.SetMaxPolys(tileNavMeshBuilder.GetMaxPolysPerTile(_sample.GetInputGeom(), settings.cellSize, settings.tileSize));
         }
 
+        //if ()
+
         UpdateKeyboard((float)dt);
 
         // camera move
@@ -494,11 +496,11 @@ public class RecastDemo : IRecastDemoChannel
 
         cameraPos.X += (float)(movex * modelviewMatrix[0]);
         cameraPos.Y += (float)(movex * modelviewMatrix[4]);
-        cameraPos.Z += (float)(movex * modelviewMatrix[8]);
+        cameraPos.Z += (float)(movex * modelviewMatrix[8]) * (settingsView.RenderAsLeftHanded ? -1 : 1);
 
         cameraPos.X += (float)(movey * modelviewMatrix[2]);
         cameraPos.Y += (float)(movey * modelviewMatrix[6]);
-        cameraPos.Z += (float)(movey * modelviewMatrix[10]);
+        cameraPos.Z += (float)(movey * modelviewMatrix[10]) * (settingsView.RenderAsLeftHanded ? -1 : 1);
 
         cameraPos.Y += (float)((_moveUp - _moveDown) * keySpeed * dt);
 
@@ -628,6 +630,7 @@ public class RecastDemo : IRecastDemoChannel
     private void OnWindowRender(double dt)
     {
         // Clear the screen
+        dd.SetAsRenderLeftHanded(settingsView.RenderAsLeftHanded);
         dd.Clear();
         dd.ProjectionMatrix(50f, (float)width / (float)height, 1.0f, camr).CopyTo(projectionMatrix);
         dd.ViewMatrix(cameraPos, cameraEulers).CopyTo(modelviewMatrix);

--- a/src/DotRecast.Recast.Demo/UI/RcSettingsView.cs
+++ b/src/DotRecast.Recast.Demo/UI/RcSettingsView.cs
@@ -45,6 +45,9 @@ public class RcSettingsView : IRcView
     private bool _isHovered;
     public bool IsHovered() => _isHovered;
 
+    public bool RenderAsLeftHanded => _renderAsLeftHanded;
+    private bool _renderAsLeftHanded = false;
+
     private DemoSample _sample;
     private RcCanvas _canvas;
 
@@ -72,6 +75,8 @@ public class RcSettingsView : IRcView
         var settings = _sample.GetSettings();
 
         ImGui.Begin("Properties");
+
+        ImGui.Checkbox("Render As Left-Handed", ref _renderAsLeftHanded);
 
         // size reset
         var size = ImGui.GetItemRectSize();


### PR DESCRIPTION
Add an option to render using a left-handed coordinate system to keep consistency with Unity's rendering:

Right handed by default:
![image](https://github.com/user-attachments/assets/8d222ffc-1d05-4c4a-89cb-2032d8ea70f3)
After checking `Render As Left-Handed`:
![image](https://github.com/user-attachments/assets/2c6d1848-35a2-41c2-87d3-8b20955493a8)
