### PR TITLE
refactor(imgui): determined whether the mouse is on the UI through WantCaptureMouse property

### DIFF
--- a/src/DotRecast.Recast.Demo/RecastDemo.cs
+++ b/src/DotRecast.Recast.Demo/RecastDemo.cs
@@ -647,7 +647,7 @@ public class RecastDemo : IRecastDemoChannel
         dd.Fog(false);
 
         _canvas.Draw(dt);
-        _mouseOverMenu = _canvas.IsMouseOver();
+        _mouseOverMenu = ImGui.GetIO().WantCaptureMouse;
 
         _imgui.Render();
 

--- a/src/DotRecast.Recast.Demo/UI/IRcView.cs
+++ b/src/DotRecast.Recast.Demo/UI/IRcView.cs
@@ -22,7 +22,6 @@ namespace DotRecast.Recast.Demo.UI;
 public interface IRcView
 {
     void Bind(RcCanvas canvas);
-    bool IsHovered();
     void Update(double dt);
     void Draw(double dt);
 }

--- a/src/DotRecast.Recast.Demo/UI/RcCanvas.cs
+++ b/src/DotRecast.Recast.Demo/UI/RcCanvas.cs
@@ -30,9 +30,6 @@ public class RcCanvas
 
     private readonly IWindow _window;
     private readonly IRcView[] _views;
-    private bool _mouseOver;
-
-    public bool IsMouseOver() => _mouseOver;
 
     public Vector2D<int> Size => _window.Size;
 
@@ -105,11 +102,9 @@ public class RcCanvas
 
     public void Draw(double dt)
     {
-        _mouseOver = false;
         foreach (var view in _views)
         {
             view.Draw(dt);
-            _mouseOver |= view.IsHovered();
         }
     }
 }

--- a/src/DotRecast.Recast.Demo/UI/RcLogView.cs
+++ b/src/DotRecast.Recast.Demo/UI/RcLogView.cs
@@ -12,8 +12,6 @@ namespace DotRecast.Recast.Demo.UI;
 public class RcLogView : IRcView
 {
     private RcCanvas _canvas;
-    private bool _isHovered;
-    public bool IsHovered() => _isHovered;
 
     private readonly List<LogMessageItem> _lines;
     private readonly ConcurrentQueue<LogMessageItem> _queues;
@@ -82,8 +80,6 @@ public class RcLogView : IRcView
 
         if (ImGui.BeginChild("scrolling", Vector2.Zero, ImGuiChildFlags.None, ImGuiWindowFlags.HorizontalScrollbar))
         {
-            _isHovered = ImGui.IsWindowHovered(ImGuiHoveredFlags.RectOnly | ImGuiHoveredFlags.RootAndChildWindows);
-
             ImGui.PushStyleVar(ImGuiStyleVar.ItemSpacing, Vector2.Zero);
 
             unsafe

--- a/src/DotRecast.Recast.Demo/UI/RcMenuView.cs
+++ b/src/DotRecast.Recast.Demo/UI/RcMenuView.cs
@@ -12,12 +12,6 @@ public class RcMenuView : IRcView
         _canvas = canvas;
     }
 
-    public bool IsHovered()
-    {
-        //throw new System.NotImplementedException();
-        return false;
-    }
-
     public void Update(double dt)
     {
         //throw new System.NotImplementedException();

--- a/src/DotRecast.Recast.Demo/UI/RcSettingsView.cs
+++ b/src/DotRecast.Recast.Demo/UI/RcSettingsView.cs
@@ -42,9 +42,6 @@ public class RcSettingsView : IRcView
 
     private int drawMode = DrawMode.DRAWMODE_NAVMESH.Idx;
 
-    private bool _isHovered;
-    public bool IsHovered() => _isHovered;
-
     public bool RenderAsLeftHanded => _renderAsLeftHanded;
     private bool _renderAsLeftHanded = false;
 
@@ -87,8 +84,6 @@ public class RcSettingsView : IRcView
             //ImGui.SetWindowPos(new Vector2(posX, 0));
             ImGui.SetWindowSize(new Vector2(width, _canvas.Size.Y));
         }
-
-        _isHovered = ImGui.IsWindowHovered(ImGuiHoveredFlags.RectOnly | ImGuiHoveredFlags.RootAndChildWindows);
 
         ImGui.Text("Input Mesh");
         ImGui.Separator();

--- a/src/DotRecast.Recast.Demo/UI/RcToolsetView.cs
+++ b/src/DotRecast.Recast.Demo/UI/RcToolsetView.cs
@@ -32,8 +32,6 @@ public class RcToolsetView : IRcView
     private ISampleTool _currentSampleTool;
     private bool enabled;
     private readonly ISampleTool[] tools;
-    private bool _isHovered;
-    public bool IsHovered() => _isHovered;
 
     private RcCanvas _canvas;
 
@@ -63,8 +61,6 @@ public class RcToolsetView : IRcView
             //ImGui.SetWindowPos(new Vector2(0, 0));
             ImGui.SetWindowSize(new Vector2(width, _canvas.Size.Y));
         }
-
-        _isHovered = ImGui.IsWindowHovered(ImGuiHoveredFlags.RectOnly | ImGuiHoveredFlags.RootAndChildWindows);
 
         for (int i = 0; i < tools.Length; ++i)
         {


### PR DESCRIPTION
Determined whether the mouse is on the UI through WantCaptureMouse property in imgui, fixed the bug where raycast became ineffective after expanding and collapsing the log view.
Without this refactor, processHitTest will always be false after expanding and collapsing log view because mouse over menu state is incorrect（_mouseOverMenu is always true after expanding and collapsing the log view)：
https://github.com/ikpil/DotRecast/blob/d944146d87a8aeb80fb2f0a20c1d2e35b2e40db1/src/DotRecast.Recast.Demo/RecastDemo.cs#L225-L244
