### PR TITLE
refactor: RcMatrix4x4f to use 'in' modifier and enforce CS9191

### DIFF
--- a/src/DotRecast.Core/DotRecast.Core.csproj
+++ b/src/DotRecast.Core/DotRecast.Core.csproj
@@ -11,6 +11,7 @@
     <RepositoryUrl>https://github.com/ikpil/DotRecast</RepositoryUrl>
     <PackageTags>game gamedev ai csharp server unity navigation game-development unity3d pathfinding pathfinder recast detour navmesh crowd-simulation recastnavigation</PackageTags>
     <PackageReleaseNotes>https://github.com/ikpil/DotRecast/blob/main/CHANGELOG.md</PackageReleaseNotes>
+    <WarningsAsErrors>$(WarningsAsErrors);CS9191</WarningsAsErrors>
   </PropertyGroup>
   
   <ItemGroup>

--- a/src/DotRecast.Core/Numerics/RcMatrix4x4f.cs
+++ b/src/DotRecast.Core/Numerics/RcMatrix4x4f.cs
@@ -109,7 +109,7 @@ namespace DotRecast.Core.Numerics
             M41 == 0f && M42 == 0f && M43 == 0f;
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static RcMatrix4x4f Mul(ref RcMatrix4x4f left, ref RcMatrix4x4f right)
+        public static RcMatrix4x4f Mul(in RcMatrix4x4f left, in RcMatrix4x4f right)
         {
             float m11 = left.M11 * right.M11 + left.M21 * right.M12 + left.M31 * right.M13 + left.M41 * right.M14;
             float m12 = left.M12 * right.M11 + left.M22 * right.M12 + left.M32 * right.M13 + left.M42 * right.M14;

--- a/src/DotRecast.Detour.Crowd/DotRecast.Detour.Crowd.csproj
+++ b/src/DotRecast.Detour.Crowd/DotRecast.Detour.Crowd.csproj
@@ -11,6 +11,7 @@
     <RepositoryUrl>https://github.com/ikpil/DotRecast</RepositoryUrl>
     <PackageTags>game gamedev ai csharp server unity navigation game-development unity3d pathfinding pathfinder recast detour navmesh crowd-simulation recastnavigation</PackageTags>
     <PackageReleaseNotes>https://github.com/ikpil/DotRecast/blob/main/CHANGELOG.md</PackageReleaseNotes>
+    <WarningsAsErrors>$(WarningsAsErrors);CS9191</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DotRecast.Detour.Dynamic/DotRecast.Detour.Dynamic.csproj
+++ b/src/DotRecast.Detour.Dynamic/DotRecast.Detour.Dynamic.csproj
@@ -11,6 +11,7 @@
     <RepositoryUrl>https://github.com/ikpil/DotRecast</RepositoryUrl>
     <PackageTags>game gamedev ai csharp server unity navigation game-development unity3d pathfinding pathfinder recast detour navmesh crowd-simulation recastnavigation</PackageTags>
     <PackageReleaseNotes>https://github.com/ikpil/DotRecast/blob/main/CHANGELOG.md</PackageReleaseNotes>
+    <WarningsAsErrors>$(WarningsAsErrors);CS9191</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DotRecast.Detour.Extras/DotRecast.Detour.Extras.csproj
+++ b/src/DotRecast.Detour.Extras/DotRecast.Detour.Extras.csproj
@@ -11,6 +11,7 @@
     <RepositoryUrl>https://github.com/ikpil/DotRecast</RepositoryUrl>
     <PackageTags>game gamedev ai csharp server unity navigation game-development unity3d pathfinding pathfinder recast detour navmesh crowd-simulation recastnavigation</PackageTags>
     <PackageReleaseNotes>https://github.com/ikpil/DotRecast/blob/main/CHANGELOG.md</PackageReleaseNotes>
+    <WarningsAsErrors>$(WarningsAsErrors);CS9191</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,7 +19,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.4"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotRecast.Detour.TileCache/DotRecast.Detour.TileCache.csproj
+++ b/src/DotRecast.Detour.TileCache/DotRecast.Detour.TileCache.csproj
@@ -11,6 +11,7 @@
     <RepositoryUrl>https://github.com/ikpil/DotRecast</RepositoryUrl>
     <PackageTags>game gamedev ai csharp server unity navigation game-development unity3d pathfinding pathfinder recast detour navmesh crowd-simulation recastnavigation</PackageTags>
     <PackageReleaseNotes>https://github.com/ikpil/DotRecast/blob/main/CHANGELOG.md</PackageReleaseNotes>
+    <WarningsAsErrors>$(WarningsAsErrors);CS9191</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DotRecast.Detour/DotRecast.Detour.csproj
+++ b/src/DotRecast.Detour/DotRecast.Detour.csproj
@@ -11,6 +11,7 @@
     <RepositoryUrl>https://github.com/ikpil/DotRecast</RepositoryUrl>
     <PackageTags>game gamedev ai csharp server unity navigation game-development unity3d pathfinding pathfinder recast detour navmesh crowd-simulation recastnavigation</PackageTags>
     <PackageReleaseNotes>https://github.com/ikpil/DotRecast/blob/main/CHANGELOG.md</PackageReleaseNotes>
+    <WarningsAsErrors>$(WarningsAsErrors);CS9191</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DotRecast.Recast.Demo/DotRecast.Recast.Demo.csproj
+++ b/src/DotRecast.Recast.Demo/DotRecast.Recast.Demo.csproj
@@ -13,6 +13,7 @@
     <RepositoryUrl>https://github.com/ikpil/DotRecast</RepositoryUrl>
     <PackageTags>game gamedev ai csharp server unity navigation game-development unity3d pathfinding pathfinder recast detour navmesh crowd-simulation recastnavigation</PackageTags>
     <PackageReleaseNotes>https://github.com/ikpil/DotRecast/blob/main/CHANGELOG.md</PackageReleaseNotes>
+    <WarningsAsErrors>$(WarningsAsErrors);CS9191</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>
@@ -20,15 +21,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" Version="4.3.0" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0" />
-    <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
-    <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="K4os.Compression.LZ4" Version="1.3.8" />
-    <PackageReference Include="Silk.NET" Version="2.22.0" />
-    <PackageReference Include="Silk.NET.OpenGL.Extensions.ImGui" Version="2.22.0" />
+    <PackageReference Include="Serilog" Version="4.3.0"/>
+    <PackageReference Include="Serilog.Settings.Configuration" Version="10.0.0"/>
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0"/>
+    <PackageReference Include="Serilog.Sinks.Async" Version="2.1.0"/>
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1"/>
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0"/>
+    <PackageReference Include="K4os.Compression.LZ4" Version="1.3.8"/>
+    <PackageReference Include="Silk.NET" Version="2.22.0"/>
+    <PackageReference Include="Silk.NET.OpenGL.Extensions.ImGui" Version="2.22.0"/>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/DotRecast.Recast.Demo/Draw/DebugDraw.cs
+++ b/src/DotRecast.Recast.Demo/Draw/DebugDraw.cs
@@ -634,7 +634,7 @@ public class DebugDraw
     public RcMatrix4x4f ProjectionMatrix(float fovy, float aspect, float near, float far)
     {
         GLU.GlhPerspectivef2(ref _projectionMatrix, fovy, aspect, near, far);
-        GetOpenGlDraw().ProjectionMatrix(ref _projectionMatrix);
+        GetOpenGlDraw().ProjectionMatrix(_projectionMatrix);
         UpdateFrustum();
         return _projectionMatrix;
     }
@@ -643,14 +643,14 @@ public class DebugDraw
     {
         var rx = RcMatrix4x4f.CreateFromRotate(cameraEulers.X, 1, 0, 0);
         var ry = RcMatrix4x4f.CreateFromRotate(cameraEulers.Y, 0, 1, 0);
-        var r = RcMatrix4x4f.Mul(ref rx, ref ry);
+        var r = RcMatrix4x4f.Mul(rx, ry);
 
         var t = new RcMatrix4x4f();
         t.M11 = t.M22 = t.M33 = t.M44 = 1;
         t.M41 = -cameraPos.X;
         t.M42 = -cameraPos.Y;
         t.M43 = -cameraPos.Z;
-        _viewMatrix = RcMatrix4x4f.Mul(ref r, ref t);
+        _viewMatrix = RcMatrix4x4f.Mul(r, t);
 
         if (_renderAsLeftHanded)
         {
@@ -659,7 +659,7 @@ public class DebugDraw
             _viewMatrix.M33 = -_viewMatrix.M33;
         }
 
-        GetOpenGlDraw().ViewMatrix(ref _viewMatrix);
+        GetOpenGlDraw().ViewMatrix(_viewMatrix);
         UpdateFrustum();
         return _viewMatrix;
     }
@@ -677,7 +677,7 @@ public class DebugDraw
 
     private void UpdateFrustum()
     {
-        var vpm = RcMatrix4x4f.Mul(ref _projectionMatrix, ref _viewMatrix);
+        var vpm = RcMatrix4x4f.Mul(_projectionMatrix, _viewMatrix);
         NormalizePlane(vpm.M14 + vpm.M11, vpm.M24 + vpm.M21, vpm.M34 + vpm.M31, vpm.M44 + vpm.M41, ref frustumPlanes[0]); // left
         NormalizePlane(vpm.M14 - vpm.M11, vpm.M24 - vpm.M21, vpm.M34 - vpm.M31, vpm.M44 - vpm.M41, ref frustumPlanes[1]); // right
         NormalizePlane(vpm.M14 - vpm.M12, vpm.M24 - vpm.M22, vpm.M34 - vpm.M32, vpm.M44 - vpm.M42, ref frustumPlanes[2]); // top

--- a/src/DotRecast.Recast.Demo/Draw/IOpenGLDraw.cs
+++ b/src/DotRecast.Recast.Demo/Draw/IOpenGLDraw.cs
@@ -27,9 +27,9 @@ public interface IOpenGLDraw
 
     void Texture(GLCheckerTexture g_tex, bool state);
 
-    void ProjectionMatrix(ref RcMatrix4x4f projectionMatrix);
+    void ProjectionMatrix(in RcMatrix4x4f projectionMatrix);
 
-    void ViewMatrix(ref RcMatrix4x4f viewMatrix);
+    void ViewMatrix(in RcMatrix4x4f viewMatrix);
 
     void Fog(float start, float end);
 }

--- a/src/DotRecast.Recast.Demo/Draw/ModernOpenGLDraw.cs
+++ b/src/DotRecast.Recast.Demo/Draw/ModernOpenGLDraw.cs
@@ -312,12 +312,12 @@ void main(){{
         }
     }
 
-    public void ProjectionMatrix(ref RcMatrix4x4f projectionMatrix)
+    public void ProjectionMatrix(in RcMatrix4x4f projectionMatrix)
     {
         projectionMatrix.CopyTo(_projectionMatrix);
     }
 
-    public void ViewMatrix(ref RcMatrix4x4f viewMatrix)
+    public void ViewMatrix(in RcMatrix4x4f viewMatrix)
     {
         viewMatrix.CopyTo(_viewMatrix);
     }

--- a/src/DotRecast.Recast.Toolset/DotRecast.Recast.Toolset.csproj
+++ b/src/DotRecast.Recast.Toolset/DotRecast.Recast.Toolset.csproj
@@ -11,6 +11,7 @@
     <RepositoryUrl>https://github.com/ikpil/DotRecast</RepositoryUrl>
     <PackageTags>game gamedev ai csharp server unity navigation game-development unity3d pathfinding pathfinder recast detour navmesh crowd-simulation recastnavigation</PackageTags>
     <PackageReleaseNotes>https://github.com/ikpil/DotRecast/blob/main/CHANGELOG.md</PackageReleaseNotes>
+    <WarningsAsErrors>$(WarningsAsErrors);CS9191</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/DotRecast.Recast.Toolset/Tools/RcDynamicUpdateTool.cs
+++ b/src/DotRecast.Recast.Toolset/Tools/RcDynamicUpdateTool.cs
@@ -311,7 +311,7 @@ namespace DotRecast.Recast.Toolset.Tools
         {
             var rx = RcMatrix4x4f.CreateFromRotate((float)random.NextDouble() * ax, 1, 0, 0);
             var ry = RcMatrix4x4f.CreateFromRotate((float)random.NextDouble() * 360, 0, 1, 0);
-            var m = RcMatrix4x4f.Mul(ref rx, ref ry);
+            var m = RcMatrix4x4f.Mul(rx, ry);
             float[] verts = new float[geom.vertices.Length];
             RcVec3f v = new RcVec3f();
             RcVec3f vr = new RcVec3f();
@@ -340,7 +340,7 @@ namespace DotRecast.Recast.Toolset.Tools
             return resultvector;
         }
 
-        private static RcVec3f MulMatrixVector(ref RcVec3f resultvector, RcMatrix4x4f matrix, RcVec3f pvector)
+        private static RcVec3f MulMatrixVector(ref RcVec3f resultvector, in RcMatrix4x4f matrix, RcVec3f pvector)
         {
             resultvector.X = matrix.M11 * pvector.X + matrix.M21 * pvector.Y + matrix.M31 * pvector.Z;
             resultvector.Y = matrix.M12 * pvector.X + matrix.M22 * pvector.Y + matrix.M32 * pvector.Z;

--- a/src/DotRecast.Recast/DotRecast.Recast.csproj
+++ b/src/DotRecast.Recast/DotRecast.Recast.csproj
@@ -11,6 +11,7 @@
     <RepositoryUrl>https://github.com/ikpil/DotRecast</RepositoryUrl>
     <PackageTags>game gamedev ai csharp server unity navigation game-development unity3d pathfinding pathfinder recast detour navmesh crowd-simulation recastnavigation</PackageTags>
     <PackageReleaseNotes>https://github.com/ikpil/DotRecast/blob/main/CHANGELOG.md</PackageReleaseNotes>
+    <WarningsAsErrors>$(WarningsAsErrors);CS9191</WarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/DotRecast.Core.Test/DotRecast.Core.Test.csproj
+++ b/test/DotRecast.Core.Test/DotRecast.Core.Test.csproj
@@ -1,27 +1,28 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <WarningsAsErrors>$(WarningsAsErrors);CS9191</WarningsAsErrors>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="NUnit" Version="4.4.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
+    <PackageReference Include="Moq" Version="4.20.72"/>
+    <PackageReference Include="NUnit" Version="4.4.0"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1"/>
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\..\src\DotRecast.Core\DotRecast.Core.csproj"/>
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\DotRecast.Core\DotRecast.Core.csproj"/>
+  </ItemGroup>
 </Project>

--- a/test/DotRecast.Detour.Crowd.Test/DotRecast.Detour.Crowd.Test.csproj
+++ b/test/DotRecast.Detour.Crowd.Test/DotRecast.Detour.Crowd.Test.csproj
@@ -1,31 +1,32 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <WarningsAsErrors>$(WarningsAsErrors);CS9191</WarningsAsErrors>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="NUnit" Version="4.4.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
+    <PackageReference Include="Moq" Version="4.20.72"/>
+    <PackageReference Include="NUnit" Version="4.4.0"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\DotRecast.Core.Test\DotRecast.Core.Test.csproj" />
-        <ProjectReference Include="..\..\src\DotRecast.Detour.Crowd\DotRecast.Detour.Crowd.csproj" />
-        <ProjectReference Include="..\..\src\DotRecast.Detour\DotRecast.Detour.csproj" />
-        <ProjectReference Include="..\..\src\DotRecast.Recast\DotRecast.Recast.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DotRecast.Core.Test\DotRecast.Core.Test.csproj"/>
+    <ProjectReference Include="..\..\src\DotRecast.Detour.Crowd\DotRecast.Detour.Crowd.csproj"/>
+    <ProjectReference Include="..\..\src\DotRecast.Detour\DotRecast.Detour.csproj"/>
+    <ProjectReference Include="..\..\src\DotRecast.Recast\DotRecast.Recast.csproj"/>
+  </ItemGroup>
 
 </Project>

--- a/test/DotRecast.Detour.Dynamic.Test/DotRecast.Detour.Dynamic.Test.csproj
+++ b/test/DotRecast.Detour.Dynamic.Test/DotRecast.Detour.Dynamic.Test.csproj
@@ -1,32 +1,33 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <WarningsAsErrors>$(WarningsAsErrors);CS9191</WarningsAsErrors>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="NUnit" Version="4.4.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="K4os.Compression.LZ4" Version="1.3.8" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
+    <PackageReference Include="Moq" Version="4.20.72"/>
+    <PackageReference Include="NUnit" Version="4.4.0"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1"/>
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="K4os.Compression.LZ4" Version="1.3.8"/>
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\DotRecast.Core.Test\DotRecast.Core.Test.csproj" />
-        <ProjectReference Include="..\..\src\DotRecast.Detour.Dynamic\DotRecast.Detour.Dynamic.csproj"/>
-        <ProjectReference Include="..\..\src\DotRecast.Detour\DotRecast.Detour.csproj"/>
-        <ProjectReference Include="..\..\src\DotRecast.Recast\DotRecast.Recast.csproj"/>
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DotRecast.Core.Test\DotRecast.Core.Test.csproj"/>
+    <ProjectReference Include="..\..\src\DotRecast.Detour.Dynamic\DotRecast.Detour.Dynamic.csproj"/>
+    <ProjectReference Include="..\..\src\DotRecast.Detour\DotRecast.Detour.csproj"/>
+    <ProjectReference Include="..\..\src\DotRecast.Recast\DotRecast.Recast.csproj"/>
+  </ItemGroup>
 
 </Project>

--- a/test/DotRecast.Detour.Extras.Test/DotRecast.Detour.Extras.Test.csproj
+++ b/test/DotRecast.Detour.Extras.Test/DotRecast.Detour.Extras.Test.csproj
@@ -1,31 +1,32 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <WarningsAsErrors>$(WarningsAsErrors);CS9191</WarningsAsErrors>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="NUnit" Version="4.4.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-    
-    <ItemGroup>
-        <ProjectReference Include="..\DotRecast.Core.Test\DotRecast.Core.Test.csproj" />
-        <ProjectReference Include="..\..\src\DotRecast.Detour.Extras\DotRecast.Detour.Extras.csproj" />
-        <ProjectReference Include="..\..\src\DotRecast.Detour\DotRecast.Detour.csproj" />
-        <ProjectReference Include="..\..\src\DotRecast.Recast\DotRecast.Recast.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
+    <PackageReference Include="Moq" Version="4.20.72"/>
+    <PackageReference Include="NUnit" Version="4.4.0"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1"/>
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DotRecast.Core.Test\DotRecast.Core.Test.csproj"/>
+    <ProjectReference Include="..\..\src\DotRecast.Detour.Extras\DotRecast.Detour.Extras.csproj"/>
+    <ProjectReference Include="..\..\src\DotRecast.Detour\DotRecast.Detour.csproj"/>
+    <ProjectReference Include="..\..\src\DotRecast.Recast\DotRecast.Recast.csproj"/>
+  </ItemGroup>
 
 </Project>

--- a/test/DotRecast.Detour.Test/DotRecast.Detour.Test.csproj
+++ b/test/DotRecast.Detour.Test/DotRecast.Detour.Test.csproj
@@ -1,30 +1,31 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <WarningsAsErrors>$(WarningsAsErrors);CS9191</WarningsAsErrors>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="NUnit" Version="4.4.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-    
-    <ItemGroup>
-        <ProjectReference Include="..\DotRecast.Core.Test\DotRecast.Core.Test.csproj" />
-        <ProjectReference Include="..\..\src\DotRecast.Detour\DotRecast.Detour.csproj" />
-        <ProjectReference Include="..\..\src\DotRecast.Recast\DotRecast.Recast.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
+    <PackageReference Include="Moq" Version="4.20.72"/>
+    <PackageReference Include="NUnit" Version="4.4.0"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1"/>
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DotRecast.Core.Test\DotRecast.Core.Test.csproj"/>
+    <ProjectReference Include="..\..\src\DotRecast.Detour\DotRecast.Detour.csproj"/>
+    <ProjectReference Include="..\..\src\DotRecast.Recast\DotRecast.Recast.csproj"/>
+  </ItemGroup>
 
 </Project>

--- a/test/DotRecast.Detour.TileCache.Test/DotRecast.Detour.TileCache.Test.csproj
+++ b/test/DotRecast.Detour.TileCache.Test/DotRecast.Detour.TileCache.Test.csproj
@@ -1,32 +1,33 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <WarningsAsErrors>$(WarningsAsErrors);CS9191</WarningsAsErrors>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="NUnit" Version="4.4.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="K4os.Compression.LZ4" Version="1.3.8" />
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
+    <PackageReference Include="Moq" Version="4.20.72"/>
+    <PackageReference Include="NUnit" Version="4.4.0"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1"/>
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="K4os.Compression.LZ4" Version="1.3.8"/>
+  </ItemGroup>
 
-    <ItemGroup>
-        <ProjectReference Include="..\DotRecast.Core.Test\DotRecast.Core.Test.csproj" />
-        <ProjectReference Include="..\..\src\DotRecast.Detour.TileCache\DotRecast.Detour.TileCache.csproj"/>
-        <ProjectReference Include="..\..\src\DotRecast.Detour\DotRecast.Detour.csproj"/>
-        <ProjectReference Include="..\..\src\DotRecast.Recast\DotRecast.Recast.csproj"/>
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\DotRecast.Core.Test\DotRecast.Core.Test.csproj"/>
+    <ProjectReference Include="..\..\src\DotRecast.Detour.TileCache\DotRecast.Detour.TileCache.csproj"/>
+    <ProjectReference Include="..\..\src\DotRecast.Detour\DotRecast.Detour.csproj"/>
+    <ProjectReference Include="..\..\src\DotRecast.Recast\DotRecast.Recast.csproj"/>
+  </ItemGroup>
 
 </Project>

--- a/test/DotRecast.Recast.Test/DotRecast.Recast.Test.csproj
+++ b/test/DotRecast.Recast.Test/DotRecast.Recast.Test.csproj
@@ -1,29 +1,30 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+    <WarningsAsErrors>$(WarningsAsErrors);CS9191</WarningsAsErrors>
+  </PropertyGroup>
 
-    <ItemGroup>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
-        <PackageReference Include="Moq" Version="4.20.72" />
-        <PackageReference Include="NUnit" Version="4.4.0" />
-        <PackageReference Include="NUnit3TestAdapter" Version="6.0.1" />
-        <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="6.0.4">
-            <PrivateAssets>all</PrivateAssets>
-            <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-        </PackageReference>
-    </ItemGroup>
-    
-    <ItemGroup>
-        <ProjectReference Include="..\DotRecast.Core.Test\DotRecast.Core.Test.csproj"/>
-        <ProjectReference Include="..\..\src\DotRecast.Recast\DotRecast.Recast.csproj"/>
-    </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1"/>
+    <PackageReference Include="Moq" Version="4.20.72"/>
+    <PackageReference Include="NUnit" Version="4.4.0"/>
+    <PackageReference Include="NUnit3TestAdapter" Version="6.0.1"/>
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DotRecast.Core.Test\DotRecast.Core.Test.csproj"/>
+    <ProjectReference Include="..\..\src\DotRecast.Recast\DotRecast.Recast.csproj"/>
+  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
- Changed RcMatrix4x4f parameters from 'ref' to 'in' in RcMatrix4x4f.Mul, IOpenGLDraw.ProjectionMatrix, and IOpenGLDraw.ViewMatrix to improve safety and performance.
- Updated RcDynamicUpdateTool.MulMatrixVector to pass RcMatrix4x4f by 'in' instead of value to avoid struct copying.
- Updated all call sites to align with the new method signatures by removing the 'ref' keyword.
- Added CS9191 to WarningsAsErrors in project files to enforce stricter handling of 'in' parameter arguments.