### PR TITLE
refactor: RcRecast.GetCon to use `in` parameter modifier

### DIFF
--- a/src/DotRecast.Recast/RcAreas.cs
+++ b/src/DotRecast.Recast/RcAreas.cs
@@ -74,7 +74,7 @@ namespace DotRecast.Recast
                             int neighborCount = 0;
                             for (int direction = 0; direction < 4; ++direction)
                             {
-                                int neighborConnection = GetCon(ref span, direction);
+                                int neighborConnection = GetCon(span, direction);
                                 if (neighborConnection == RC_NOT_CONNECTED)
                                 {
                                     break;
@@ -82,7 +82,7 @@ namespace DotRecast.Recast
 
                                 int neighborX = x + GetDirOffsetX(direction);
                                 int neighborZ = z + GetDirOffsetY(direction);
-                                int neighborSpanIndex = compactHeightfield.cells[neighborX + neighborZ * zStride].index + GetCon(ref span, direction);
+                                int neighborSpanIndex = compactHeightfield.cells[neighborX + neighborZ * zStride].index + GetCon(span, direction);
                                 if (compactHeightfield.areas[neighborSpanIndex] == RC_NULL_AREA)
                                 {
                                     break;
@@ -114,12 +114,12 @@ namespace DotRecast.Recast
                     {
                         ref RcCompactSpan span = ref compactHeightfield.spans[spanIndex];
 
-                        if (GetCon(ref span, 0) != RC_NOT_CONNECTED)
+                        if (GetCon(span, 0) != RC_NOT_CONNECTED)
                         {
                             // (-1,0)
                             int aX = x + GetDirOffsetX(0);
                             int aY = z + GetDirOffsetY(0);
-                            int aIndex = compactHeightfield.cells[aX + aY * xSize].index + GetCon(ref span, 0);
+                            int aIndex = compactHeightfield.cells[aX + aY * xSize].index + GetCon(span, 0);
                             ref RcCompactSpan aSpan = ref compactHeightfield.spans[aIndex];
                             newDistance = Math.Min(distanceToBoundary[aIndex] + 2, 255);
                             if (newDistance < distanceToBoundary[spanIndex])
@@ -128,11 +128,11 @@ namespace DotRecast.Recast
                             }
 
                             // (-1,-1)
-                            if (GetCon(ref aSpan, 3) != RC_NOT_CONNECTED)
+                            if (GetCon(aSpan, 3) != RC_NOT_CONNECTED)
                             {
                                 int bX = aX + GetDirOffsetX(3);
                                 int bY = aY + GetDirOffsetY(3);
-                                int bIndex = compactHeightfield.cells[bX + bY * xSize].index + GetCon(ref aSpan, 3);
+                                int bIndex = compactHeightfield.cells[bX + bY * xSize].index + GetCon(aSpan, 3);
                                 newDistance = Math.Min(distanceToBoundary[bIndex] + 3, 255);
                                 if (newDistance < distanceToBoundary[spanIndex])
                                 {
@@ -141,12 +141,12 @@ namespace DotRecast.Recast
                             }
                         }
 
-                        if (GetCon(ref span, 3) != RC_NOT_CONNECTED)
+                        if (GetCon(span, 3) != RC_NOT_CONNECTED)
                         {
                             // (0,-1)
                             int aX = x + GetDirOffsetX(3);
                             int aY = z + GetDirOffsetY(3);
-                            int aIndex = compactHeightfield.cells[aX + aY * xSize].index + GetCon(ref span, 3);
+                            int aIndex = compactHeightfield.cells[aX + aY * xSize].index + GetCon(span, 3);
                             ref RcCompactSpan aSpan = ref compactHeightfield.spans[aIndex];
                             newDistance = Math.Min(distanceToBoundary[aIndex] + 2, 255);
                             if (newDistance < distanceToBoundary[spanIndex])
@@ -155,11 +155,11 @@ namespace DotRecast.Recast
                             }
 
                             // (1,-1)
-                            if (GetCon(ref aSpan, 2) != RC_NOT_CONNECTED)
+                            if (GetCon(aSpan, 2) != RC_NOT_CONNECTED)
                             {
                                 int bX = aX + GetDirOffsetX(2);
                                 int bY = aY + GetDirOffsetY(2);
-                                int bIndex = compactHeightfield.cells[bX + bY * xSize].index + GetCon(ref aSpan, 2);
+                                int bIndex = compactHeightfield.cells[bX + bY * xSize].index + GetCon(aSpan, 2);
                                 newDistance = Math.Min(distanceToBoundary[bIndex] + 3, 255);
                                 if (newDistance < distanceToBoundary[spanIndex])
                                 {
@@ -182,12 +182,12 @@ namespace DotRecast.Recast
                     {
                         ref RcCompactSpan span = ref compactHeightfield.spans[i];
 
-                        if (GetCon(ref span, 2) != RC_NOT_CONNECTED)
+                        if (GetCon(span, 2) != RC_NOT_CONNECTED)
                         {
                             // (1,0)
                             int aX = x + GetDirOffsetX(2);
                             int aY = z + GetDirOffsetY(2);
-                            int aIndex = compactHeightfield.cells[aX + aY * xSize].index + GetCon(ref span, 2);
+                            int aIndex = compactHeightfield.cells[aX + aY * xSize].index + GetCon(span, 2);
                             ref RcCompactSpan aSpan = ref compactHeightfield.spans[aIndex];
                             newDistance = Math.Min(distanceToBoundary[aIndex] + 2, 255);
                             if (newDistance < distanceToBoundary[i])
@@ -196,11 +196,11 @@ namespace DotRecast.Recast
                             }
 
                             // (1,1)
-                            if (GetCon(ref aSpan, 1) != RC_NOT_CONNECTED)
+                            if (GetCon(aSpan, 1) != RC_NOT_CONNECTED)
                             {
                                 int bX = aX + GetDirOffsetX(1);
                                 int bY = aY + GetDirOffsetY(1);
-                                int bIndex = compactHeightfield.cells[bX + bY * xSize].index + GetCon(ref aSpan, 1);
+                                int bIndex = compactHeightfield.cells[bX + bY * xSize].index + GetCon(aSpan, 1);
                                 newDistance = Math.Min(distanceToBoundary[bIndex] + 3, 255);
                                 if (newDistance < distanceToBoundary[i])
                                 {
@@ -209,12 +209,12 @@ namespace DotRecast.Recast
                             }
                         }
 
-                        if (GetCon(ref span, 1) != RC_NOT_CONNECTED)
+                        if (GetCon(span, 1) != RC_NOT_CONNECTED)
                         {
                             // (0,1)
                             int aX = x + GetDirOffsetX(1);
                             int aY = z + GetDirOffsetY(1);
-                            int aIndex = compactHeightfield.cells[aX + aY * xSize].index + GetCon(ref span, 1);
+                            int aIndex = compactHeightfield.cells[aX + aY * xSize].index + GetCon(span, 1);
                             ref RcCompactSpan aSpan = ref compactHeightfield.spans[aIndex];
                             newDistance = Math.Min(distanceToBoundary[aIndex] + 2, 255);
                             if (newDistance < distanceToBoundary[i])
@@ -223,11 +223,11 @@ namespace DotRecast.Recast
                             }
 
                             // (-1,1)
-                            if (GetCon(ref aSpan, 0) != RC_NOT_CONNECTED)
+                            if (GetCon(aSpan, 0) != RC_NOT_CONNECTED)
                             {
                                 int bX = aX + GetDirOffsetX(0);
                                 int bY = aY + GetDirOffsetY(0);
-                                int bIndex = compactHeightfield.cells[bX + bY * xSize].index + GetCon(ref aSpan, 0);
+                                int bIndex = compactHeightfield.cells[bX + bY * xSize].index + GetCon(aSpan, 0);
                                 newDistance = Math.Min(distanceToBoundary[bIndex] + 3, 255);
                                 if (newDistance < distanceToBoundary[i])
                                 {
@@ -293,14 +293,14 @@ namespace DotRecast.Recast
 
                         for (int dir = 0; dir < 4; ++dir)
                         {
-                            if (GetCon(ref span, dir) == RC_NOT_CONNECTED)
+                            if (GetCon(span, dir) == RC_NOT_CONNECTED)
                             {
                                 continue;
                             }
 
                             int aX = x + GetDirOffsetX(dir);
                             int aZ = z + GetDirOffsetY(dir);
-                            int aIndex = compactHeightfield.cells[aX + aZ * zStride].index + GetCon(ref span, dir);
+                            int aIndex = compactHeightfield.cells[aX + aZ * zStride].index + GetCon(span, dir);
                             if (compactHeightfield.areas[aIndex] != RC_NULL_AREA)
                             {
                                 neighborAreas[dir * 2 + 0] = compactHeightfield.areas[aIndex];
@@ -308,12 +308,12 @@ namespace DotRecast.Recast
 
                             ref RcCompactSpan aSpan = ref compactHeightfield.spans[aIndex];
                             int dir2 = (dir + 1) & 0x3;
-                            int neighborConnection2 = GetCon(ref aSpan, dir2);
+                            int neighborConnection2 = GetCon(aSpan, dir2);
                             if (neighborConnection2 != RC_NOT_CONNECTED)
                             {
                                 int bX = aX + GetDirOffsetX(dir2);
                                 int bZ = aZ + GetDirOffsetY(dir2);
-                                int bIndex = compactHeightfield.cells[bX + bZ * zStride].index + GetCon(ref aSpan, dir2);
+                                int bIndex = compactHeightfield.cells[bX + bZ * zStride].index + GetCon(aSpan, dir2);
                                 if (compactHeightfield.areas[bIndex] != RC_NULL_AREA)
                                 {
                                     neighborAreas[dir * 2 + 1] = compactHeightfield.areas[bIndex];

--- a/src/DotRecast.Recast/RcContours.cs
+++ b/src/DotRecast.Recast/RcContours.cs
@@ -46,38 +46,38 @@ namespace DotRecast.Recast
             // border vertices which are in between two areas to be removed.
             regs[0] = chf.spans[i].reg | (chf.areas[i] << 16);
 
-            if (GetCon(ref s, dir) != RC_NOT_CONNECTED)
+            if (GetCon(s, dir) != RC_NOT_CONNECTED)
             {
                 int ax = x + GetDirOffsetX(dir);
                 int ay = y + GetDirOffsetY(dir);
-                int ai = chf.cells[ax + ay * chf.width].index + GetCon(ref s, dir);
+                int ai = chf.cells[ax + ay * chf.width].index + GetCon(s, dir);
                 ref RcCompactSpan @as = ref chf.spans[ai];
                 ch = Math.Max(ch, @as.y);
                 regs[1] = chf.spans[ai].reg | (chf.areas[ai] << 16);
-                if (GetCon(ref @as, dirp) != RC_NOT_CONNECTED)
+                if (GetCon(@as, dirp) != RC_NOT_CONNECTED)
                 {
                     int ax2 = ax + GetDirOffsetX(dirp);
                     int ay2 = ay + GetDirOffsetY(dirp);
-                    int ai2 = chf.cells[ax2 + ay2 * chf.width].index + GetCon(ref @as, dirp);
+                    int ai2 = chf.cells[ax2 + ay2 * chf.width].index + GetCon(@as, dirp);
                     ref RcCompactSpan as2 = ref chf.spans[ai2];
                     ch = Math.Max(ch, as2.y);
                     regs[2] = chf.spans[ai2].reg | (chf.areas[ai2] << 16);
                 }
             }
 
-            if (GetCon(ref s, dirp) != RC_NOT_CONNECTED)
+            if (GetCon(s, dirp) != RC_NOT_CONNECTED)
             {
                 int ax = x + GetDirOffsetX(dirp);
                 int ay = y + GetDirOffsetY(dirp);
-                int ai = chf.cells[ax + ay * chf.width].index + GetCon(ref s, dirp);
+                int ai = chf.cells[ax + ay * chf.width].index + GetCon(s, dirp);
                 ref RcCompactSpan @as = ref chf.spans[ai];
                 ch = Math.Max(ch, @as.y);
                 regs[3] = chf.spans[ai].reg | (chf.areas[ai] << 16);
-                if (GetCon(ref @as, dir) != RC_NOT_CONNECTED)
+                if (GetCon(@as, dir) != RC_NOT_CONNECTED)
                 {
                     int ax2 = ax + GetDirOffsetX(dir);
                     int ay2 = ay + GetDirOffsetY(dir);
-                    int ai2 = chf.cells[ax2 + ay2 * chf.width].index + GetCon(ref @as, dir);
+                    int ai2 = chf.cells[ax2 + ay2 * chf.width].index + GetCon(@as, dir);
                     ref RcCompactSpan as2 = ref chf.spans[ai2];
                     ch = Math.Max(ch, as2.y);
                     regs[2] = chf.spans[ai2].reg | (chf.areas[ai2] << 16);
@@ -147,11 +147,11 @@ namespace DotRecast.Recast
 
                     int r = 0;
                     ref RcCompactSpan s = ref chf.spans[i];
-                    if (GetCon(ref s, dir) != RC_NOT_CONNECTED)
+                    if (GetCon(s, dir) != RC_NOT_CONNECTED)
                     {
                         int ax = x + GetDirOffsetX(dir);
                         int ay = y + GetDirOffsetY(dir);
-                        int ai = chf.cells[ax + ay * chf.width].index + GetCon(ref s, dir);
+                        int ai = chf.cells[ax + ay * chf.width].index + GetCon(s, dir);
                         r = chf.spans[ai].reg;
                         if (area != chf.areas[ai])
                             isAreaBorder = true;
@@ -175,10 +175,10 @@ namespace DotRecast.Recast
                     int nx = x + GetDirOffsetX(dir);
                     int ny = y + GetDirOffsetY(dir);
                     ref RcCompactSpan s = ref chf.spans[i];
-                    if (GetCon(ref s, dir) != RC_NOT_CONNECTED)
+                    if (GetCon(s, dir) != RC_NOT_CONNECTED)
                     {
                         ref RcCompactCell nc = ref chf.cells[nx + ny * chf.width];
-                        ni = nc.index + GetCon(ref s, dir);
+                        ni = nc.index + GetCon(s, dir);
                     }
 
                     if (ni == -1)
@@ -767,11 +767,11 @@ namespace DotRecast.Recast
                         for (int dir = 0; dir < 4; ++dir)
                         {
                             int r = 0;
-                            if (GetCon(ref s, dir) != RC_NOT_CONNECTED)
+                            if (GetCon(s, dir) != RC_NOT_CONNECTED)
                             {
                                 int ax = x + GetDirOffsetX(dir);
                                 int ay = y + GetDirOffsetY(dir);
-                                int ai = chf.cells[ax + ay * w].index + GetCon(ref s, dir);
+                                int ai = chf.cells[ax + ay * w].index + GetCon(s, dir);
                                 r = chf.spans[ai].reg;
                             }
 

--- a/src/DotRecast.Recast/RcLayers.cs
+++ b/src/DotRecast.Recast/RcLayers.cs
@@ -108,11 +108,11 @@ namespace DotRecast.Recast
                         byte sid = 0xFF;
 
                         // -x
-                        if (GetCon(ref s, 0) != RC_NOT_CONNECTED)
+                        if (GetCon(s, 0) != RC_NOT_CONNECTED)
                         {
                             int ax = x + GetDirOffsetX(0);
                             int ay = y + GetDirOffsetY(0);
-                            int ai = chf.cells[ax + ay * w].index + GetCon(ref s, 0);
+                            int ai = chf.cells[ax + ay * w].index + GetCon(s, 0);
                             if (chf.areas[ai] != RC_NULL_AREA && srcReg[ai] != 0xff)
                                 sid = srcReg[ai];
                         }
@@ -125,11 +125,11 @@ namespace DotRecast.Recast
                         }
 
                         // -y
-                        if (GetCon(ref s, 3) != RC_NOT_CONNECTED)
+                        if (GetCon(s, 3) != RC_NOT_CONNECTED)
                         {
                             int ax = x + GetDirOffsetX(3);
                             int ay = y + GetDirOffsetY(3);
-                            int ai = chf.cells[ax + ay * w].index + GetCon(ref s, 3);
+                            int ai = chf.cells[ax + ay * w].index + GetCon(s, 3);
                             byte nr = srcReg[ai];
                             if (nr != 0xff)
                             {
@@ -225,11 +225,11 @@ namespace DotRecast.Recast
                         // Update neighbours
                         for (int dir = 0; dir < 4; ++dir)
                         {
-                            if (GetCon(ref s, dir) != RC_NOT_CONNECTED)
+                            if (GetCon(s, dir) != RC_NOT_CONNECTED)
                             {
                                 int ax = x + GetDirOffsetX(dir);
                                 int ay = y + GetDirOffsetY(dir);
-                                int ai = chf.cells[ax + ay * w].index + GetCon(ref s, dir);
+                                int ai = chf.cells[ax + ay * w].index + GetCon(s, dir);
                                 int rai = srcReg[ai];
                                 if (rai != 0xff && rai != ri)
                                 {
@@ -538,11 +538,11 @@ namespace DotRecast.Recast
                             char con = (char)0;
                             for (int dir = 0; dir < 4; ++dir)
                             {
-                                if (GetCon(ref s, dir) != RC_NOT_CONNECTED)
+                                if (GetCon(s, dir) != RC_NOT_CONNECTED)
                                 {
                                     int ax = cx + GetDirOffsetX(dir);
                                     int ay = cy + GetDirOffsetY(dir);
-                                    int ai = chf.cells[ax + ay * w].index + GetCon(ref s, dir);
+                                    int ai = chf.cells[ax + ay * w].index + GetCon(s, dir);
                                     int alid = srcReg[ai] != 0xff ? regs[srcReg[ai]].layerId : 0xff;
                                     // Portal mask
                                     if (chf.areas[ai] != RC_NULL_AREA && lid != alid)

--- a/src/DotRecast.Recast/RcMeshDetails.cs
+++ b/src/DotRecast.Recast/RcMeshDetails.cs
@@ -1133,7 +1133,7 @@ namespace DotRecast.Recast
                 for (int i = 0; i < 4; ++i)
                 {
                     int dir = dirs[i];
-                    if (GetCon(ref cs, dir) == RC_NOT_CONNECTED)
+                    if (GetCon(cs, dir) == RC_NOT_CONNECTED)
                     {
                         continue;
                     }
@@ -1157,7 +1157,7 @@ namespace DotRecast.Recast
 
                     array.Add(newX);
                     array.Add(newY);
-                    array.Add(chf.cells[(newX + bs) + (newY + bs) * chf.width].index + GetCon(ref cs, dir));
+                    array.Add(chf.cells[(newX + bs) + (newY + bs) * chf.width].index + GetCon(cs, dir));
                 }
 
                 tmp = dirs[3];
@@ -1225,11 +1225,11 @@ namespace DotRecast.Recast
                                 bool border = false;
                                 for (int dir = 0; dir < 4; ++dir)
                                 {
-                                    if (GetCon(ref s, dir) != RC_NOT_CONNECTED)
+                                    if (GetCon(s, dir) != RC_NOT_CONNECTED)
                                     {
                                         int ax = x + GetDirOffsetX(dir);
                                         int ay = y + GetDirOffsetY(dir);
-                                        int ai = chf.cells[ax + ay * chf.width].index + GetCon(ref s, dir);
+                                        int ai = chf.cells[ax + ay * chf.width].index + GetCon(s, dir);
                                         ref RcCompactSpan @as = ref chf.spans[ai];
                                         if (@as.reg != region)
                                         {
@@ -1280,7 +1280,7 @@ namespace DotRecast.Recast
                 ref RcCompactSpan cs = ref chf.spans[ci];
                 for (int dir = 0; dir < 4; ++dir)
                 {
-                    if (GetCon(ref cs, dir) == RC_NOT_CONNECTED)
+                    if (GetCon(cs, dir) == RC_NOT_CONNECTED)
                     {
                         continue;
                     }
@@ -1300,7 +1300,7 @@ namespace DotRecast.Recast
                         continue;
                     }
 
-                    int ai = chf.cells[ax + ay * chf.width].index + GetCon(ref cs, dir);
+                    int ai = chf.cells[ax + ay * chf.width].index + GetCon(cs, dir);
                     ref RcCompactSpan @as = ref chf.spans[ai];
 
                     hp.data[hx + hy * hp.width] = @as.y;

--- a/src/DotRecast.Recast/RcRecast.cs
+++ b/src/DotRecast.Recast/RcRecast.cs
@@ -118,7 +118,7 @@ namespace DotRecast.Recast
         /// @param[in]		span		The span to check.
         /// @param[in]		direction	The direction to check. [Limits: 0 <= value < 4]
         /// @return The neighbor connection data for the specified direction, or #RC_NOT_CONNECTED if there is no connection.
-        public static int GetCon(ref RcCompactSpan s, int dir)
+        public static int GetCon(in RcCompactSpan s, int dir)
         {
             int shift = dir * 6;
             return (s.con >> shift) & 0x3f;

--- a/src/DotRecast.Recast/RcRegions.cs
+++ b/src/DotRecast.Recast/RcRegions.cs
@@ -58,11 +58,11 @@ namespace DotRecast.Recast
                         int nc = 0;
                         for (int dir = 0; dir < 4; ++dir)
                         {
-                            if (GetCon(ref s, dir) != RC_NOT_CONNECTED)
+                            if (GetCon(s, dir) != RC_NOT_CONNECTED)
                             {
                                 int ax = x + GetDirOffsetX(dir);
                                 int ay = y + GetDirOffsetY(dir);
-                                int ai = chf.cells[ax + ay * w].index + GetCon(ref s, dir);
+                                int ai = chf.cells[ax + ay * w].index + GetCon(s, dir);
                                 if (area == chf.areas[ai])
                                 {
                                     nc++;
@@ -88,12 +88,12 @@ namespace DotRecast.Recast
                     {
                         ref RcCompactSpan s = ref chf.spans[i];
 
-                        if (GetCon(ref s, 0) != RC_NOT_CONNECTED)
+                        if (GetCon(s, 0) != RC_NOT_CONNECTED)
                         {
                             // (-1,0)
                             int ax = x + GetDirOffsetX(0);
                             int ay = y + GetDirOffsetY(0);
-                            int ai = chf.cells[ax + ay * w].index + GetCon(ref s, 0);
+                            int ai = chf.cells[ax + ay * w].index + GetCon(s, 0);
                             ref RcCompactSpan @as = ref chf.spans[ai];
                             if (src[ai] + 2 < src[i])
                             {
@@ -101,11 +101,11 @@ namespace DotRecast.Recast
                             }
 
                             // (-1,-1)
-                            if (GetCon(ref @as, 3) != RC_NOT_CONNECTED)
+                            if (GetCon(@as, 3) != RC_NOT_CONNECTED)
                             {
                                 int aax = ax + GetDirOffsetX(3);
                                 int aay = ay + GetDirOffsetY(3);
-                                int aai = chf.cells[aax + aay * w].index + GetCon(ref @as, 3);
+                                int aai = chf.cells[aax + aay * w].index + GetCon(@as, 3);
                                 if (src[aai] + 3 < src[i])
                                 {
                                     src[i] = src[aai] + 3;
@@ -113,12 +113,12 @@ namespace DotRecast.Recast
                             }
                         }
 
-                        if (GetCon(ref s, 3) != RC_NOT_CONNECTED)
+                        if (GetCon(s, 3) != RC_NOT_CONNECTED)
                         {
                             // (0,-1)
                             int ax = x + GetDirOffsetX(3);
                             int ay = y + GetDirOffsetY(3);
-                            int ai = chf.cells[ax + ay * w].index + GetCon(ref s, 3);
+                            int ai = chf.cells[ax + ay * w].index + GetCon(s, 3);
                             ref RcCompactSpan @as = ref chf.spans[ai];
                             if (src[ai] + 2 < src[i])
                             {
@@ -126,11 +126,11 @@ namespace DotRecast.Recast
                             }
 
                             // (1,-1)
-                            if (GetCon(ref @as, 2) != RC_NOT_CONNECTED)
+                            if (GetCon(@as, 2) != RC_NOT_CONNECTED)
                             {
                                 int aax = ax + GetDirOffsetX(2);
                                 int aay = ay + GetDirOffsetY(2);
-                                int aai = chf.cells[aax + aay * w].index + GetCon(ref @as, 2);
+                                int aai = chf.cells[aax + aay * w].index + GetCon(@as, 2);
                                 if (src[aai] + 3 < src[i])
                                 {
                                     src[i] = src[aai] + 3;
@@ -151,12 +151,12 @@ namespace DotRecast.Recast
                     {
                         ref RcCompactSpan s = ref chf.spans[i];
 
-                        if (GetCon(ref s, 2) != RC_NOT_CONNECTED)
+                        if (GetCon(s, 2) != RC_NOT_CONNECTED)
                         {
                             // (1,0)
                             int ax = x + GetDirOffsetX(2);
                             int ay = y + GetDirOffsetY(2);
-                            int ai = chf.cells[ax + ay * w].index + GetCon(ref s, 2);
+                            int ai = chf.cells[ax + ay * w].index + GetCon(s, 2);
                             ref RcCompactSpan @as = ref chf.spans[ai];
                             if (src[ai] + 2 < src[i])
                             {
@@ -164,11 +164,11 @@ namespace DotRecast.Recast
                             }
 
                             // (1,1)
-                            if (GetCon(ref @as, 1) != RC_NOT_CONNECTED)
+                            if (GetCon(@as, 1) != RC_NOT_CONNECTED)
                             {
                                 int aax = ax + GetDirOffsetX(1);
                                 int aay = ay + GetDirOffsetY(1);
-                                int aai = chf.cells[aax + aay * w].index + GetCon(ref @as, 1);
+                                int aai = chf.cells[aax + aay * w].index + GetCon(@as, 1);
                                 if (src[aai] + 3 < src[i])
                                 {
                                     src[i] = src[aai] + 3;
@@ -176,12 +176,12 @@ namespace DotRecast.Recast
                             }
                         }
 
-                        if (GetCon(ref s, 1) != RC_NOT_CONNECTED)
+                        if (GetCon(s, 1) != RC_NOT_CONNECTED)
                         {
                             // (0,1)
                             int ax = x + GetDirOffsetX(1);
                             int ay = y + GetDirOffsetY(1);
-                            int ai = chf.cells[ax + ay * w].index + GetCon(ref s, 1);
+                            int ai = chf.cells[ax + ay * w].index + GetCon(s, 1);
                             ref RcCompactSpan @as = ref chf.spans[ai];
                             if (src[ai] + 2 < src[i])
                             {
@@ -189,11 +189,11 @@ namespace DotRecast.Recast
                             }
 
                             // (-1,1)
-                            if (GetCon(ref @as, 0) != RC_NOT_CONNECTED)
+                            if (GetCon(@as, 0) != RC_NOT_CONNECTED)
                             {
                                 int aax = ax + GetDirOffsetX(0);
                                 int aay = ay + GetDirOffsetY(0);
-                                int aai = chf.cells[aax + aay * w].index + GetCon(ref @as, 0);
+                                int aai = chf.cells[aax + aay * w].index + GetCon(@as, 0);
                                 if (src[aai] + 3 < src[i])
                                 {
                                     src[i] = src[aai] + 3;
@@ -239,20 +239,20 @@ namespace DotRecast.Recast
                         int d = cd;
                         for (int dir = 0; dir < 4; ++dir)
                         {
-                            if (GetCon(ref s, dir) != RC_NOT_CONNECTED)
+                            if (GetCon(s, dir) != RC_NOT_CONNECTED)
                             {
                                 int ax = x + GetDirOffsetX(dir);
                                 int ay = y + GetDirOffsetY(dir);
-                                int ai = chf.cells[ax + ay * w].index + GetCon(ref s, dir);
+                                int ai = chf.cells[ax + ay * w].index + GetCon(s, dir);
                                 d += src[ai];
 
                                 ref RcCompactSpan @as = ref chf.spans[ai];
                                 int dir2 = (dir + 1) & 0x3;
-                                if (GetCon(ref @as, dir2) != RC_NOT_CONNECTED)
+                                if (GetCon(@as, dir2) != RC_NOT_CONNECTED)
                                 {
                                     int ax2 = ax + GetDirOffsetX(dir2);
                                     int ay2 = ay + GetDirOffsetY(dir2);
-                                    int ai2 = chf.cells[ax2 + ay2 * w].index + GetCon(ref @as, dir2);
+                                    int ai2 = chf.cells[ax2 + ay2 * w].index + GetCon(@as, dir2);
                                     d += src[ai2];
                                 }
                                 else
@@ -309,11 +309,11 @@ namespace DotRecast.Recast
                 for (int dir = 0; dir < 4; ++dir)
                 {
                     // 8 connected
-                    if (GetCon(ref cs, dir) != RC_NOT_CONNECTED)
+                    if (GetCon(cs, dir) != RC_NOT_CONNECTED)
                     {
                         int ax = cx + GetDirOffsetX(dir);
                         int ay = cy + GetDirOffsetY(dir);
-                        int ai = chf.cells[ax + ay * w].index + GetCon(ref cs, dir);
+                        int ai = chf.cells[ax + ay * w].index + GetCon(cs, dir);
                         if (chf.areas[ai] != area)
                         {
                             continue;
@@ -334,11 +334,11 @@ namespace DotRecast.Recast
                         ref RcCompactSpan @as = ref chf.spans[ai];
 
                         int dir2 = (dir + 1) & 0x3;
-                        if (GetCon(ref @as, dir2) != RC_NOT_CONNECTED)
+                        if (GetCon(@as, dir2) != RC_NOT_CONNECTED)
                         {
                             int ax2 = ax + GetDirOffsetX(dir2);
                             int ay2 = ay + GetDirOffsetY(dir2);
-                            int ai2 = chf.cells[ax2 + ay2 * w].index + GetCon(ref @as, dir2);
+                            int ai2 = chf.cells[ax2 + ay2 * w].index + GetCon(@as, dir2);
                             if (chf.areas[ai2] != area)
                             {
                                 continue;
@@ -365,11 +365,11 @@ namespace DotRecast.Recast
                 // Expand neighbours.
                 for (int dir = 0; dir < 4; ++dir)
                 {
-                    if (GetCon(ref cs, dir) != RC_NOT_CONNECTED)
+                    if (GetCon(cs, dir) != RC_NOT_CONNECTED)
                     {
                         int ax = cx + GetDirOffsetX(dir);
                         int ay = cy + GetDirOffsetY(dir);
-                        int ai = chf.cells[ax + ay * w].index + GetCon(ref cs, dir);
+                        int ai = chf.cells[ax + ay * w].index + GetCon(cs, dir);
                         if (chf.areas[ai] != area)
                         {
                             continue;
@@ -453,14 +453,14 @@ namespace DotRecast.Recast
                     ref RcCompactSpan s = ref chf.spans[i];
                     for (int dir = 0; dir < 4; ++dir)
                     {
-                        if (GetCon(ref s, dir) == RC_NOT_CONNECTED)
+                        if (GetCon(s, dir) == RC_NOT_CONNECTED)
                         {
                             continue;
                         }
 
                         int ax = x + GetDirOffsetX(dir);
                         int ay = y + GetDirOffsetY(dir);
-                        int ai = chf.cells[ax + ay * w].index + GetCon(ref s, dir);
+                        int ai = chf.cells[ax + ay * w].index + GetCon(s, dir);
                         if (chf.areas[ai] != area)
                         {
                             continue;
@@ -735,11 +735,11 @@ namespace DotRecast.Recast
         {
             ref RcCompactSpan s = ref chf.spans[i];
             int r = 0;
-            if (GetCon(ref s, dir) != RC_NOT_CONNECTED)
+            if (GetCon(s, dir) != RC_NOT_CONNECTED)
             {
                 int ax = x + GetDirOffsetX(dir);
                 int ay = y + GetDirOffsetY(dir);
-                int ai = chf.cells[ax + ay * chf.width].index + GetCon(ref s, dir);
+                int ai = chf.cells[ax + ay * chf.width].index + GetCon(s, dir);
                 r = srcReg[ai];
             }
 
@@ -759,11 +759,11 @@ namespace DotRecast.Recast
 
             ref RcCompactSpan ss = ref chf.spans[i];
             int curReg = 0;
-            if (GetCon(ref ss, dir) != RC_NOT_CONNECTED)
+            if (GetCon(ss, dir) != RC_NOT_CONNECTED)
             {
                 int ax = x + GetDirOffsetX(dir);
                 int ay = y + GetDirOffsetY(dir);
-                int ai = chf.cells[ax + ay * chf.width].index + GetCon(ref ss, dir);
+                int ai = chf.cells[ax + ay * chf.width].index + GetCon(ss, dir);
                 curReg = srcReg[ai];
             }
 
@@ -778,11 +778,11 @@ namespace DotRecast.Recast
                 {
                     // Choose the edge corner
                     int r = 0;
-                    if (GetCon(ref s, dir) != RC_NOT_CONNECTED)
+                    if (GetCon(s, dir) != RC_NOT_CONNECTED)
                     {
                         int ax = x + GetDirOffsetX(dir);
                         int ay = y + GetDirOffsetY(dir);
-                        int ai = chf.cells[ax + ay * chf.width].index + GetCon(ref s, dir);
+                        int ai = chf.cells[ax + ay * chf.width].index + GetCon(s, dir);
                         r = srcReg[ai];
                     }
 
@@ -799,10 +799,10 @@ namespace DotRecast.Recast
                     int ni = -1;
                     int nx = x + GetDirOffsetX(dir);
                     int ny = y + GetDirOffsetY(dir);
-                    if (GetCon(ref s, dir) != RC_NOT_CONNECTED)
+                    if (GetCon(s, dir) != RC_NOT_CONNECTED)
                     {
                         ref RcCompactCell nc = ref chf.cells[nx + ny * chf.width];
-                        ni = nc.index + GetCon(ref s, dir);
+                        ni = nc.index + GetCon(s, dir);
                     }
 
                     if (ni == -1)
@@ -1211,11 +1211,11 @@ namespace DotRecast.Recast
                         // Update neighbours
                         for (int dir = 0; dir < 4; ++dir)
                         {
-                            if (GetCon(ref s, dir) != RC_NOT_CONNECTED)
+                            if (GetCon(s, dir) != RC_NOT_CONNECTED)
                             {
                                 int ax = x + GetDirOffsetX(dir);
                                 int ay = y + GetDirOffsetY(dir);
-                                int ai = chf.cells[ax + ay * w].index + GetCon(ref s, dir);
+                                int ai = chf.cells[ax + ay * w].index + GetCon(s, dir);
                                 int rai = srcReg[ai];
                                 if (rai > 0 && rai < nreg && rai != ri)
                                 {
@@ -1539,11 +1539,11 @@ namespace DotRecast.Recast
 
                         // -x
                         int previd = 0;
-                        if (GetCon(ref s, 0) != RC_NOT_CONNECTED)
+                        if (GetCon(s, 0) != RC_NOT_CONNECTED)
                         {
                             int ax = x + GetDirOffsetX(0);
                             int ay = y + GetDirOffsetY(0);
-                            int ai = chf.cells[ax + ay * w].index + GetCon(ref s, 0);
+                            int ai = chf.cells[ax + ay * w].index + GetCon(s, 0);
                             if ((srcReg[ai] & RC_BORDER_REG) == 0 && chf.areas[i] == chf.areas[ai])
                             {
                                 previd = srcReg[ai];
@@ -1559,11 +1559,11 @@ namespace DotRecast.Recast
                         }
 
                         // -y
-                        if (GetCon(ref s, 3) != RC_NOT_CONNECTED)
+                        if (GetCon(s, 3) != RC_NOT_CONNECTED)
                         {
                             int ax = x + GetDirOffsetX(3);
                             int ay = y + GetDirOffsetY(3);
-                            int ai = chf.cells[ax + ay * w].index + GetCon(ref s, 3);
+                            int ai = chf.cells[ax + ay * w].index + GetCon(s, 3);
                             if (srcReg[ai] != 0 && (srcReg[ai] & RC_BORDER_REG) == 0 && chf.areas[i] == chf.areas[ai])
                             {
                                 int nr = srcReg[ai];
@@ -1846,11 +1846,11 @@ namespace DotRecast.Recast
 
                         // -x
                         int previd = 0;
-                        if (GetCon(ref s, 0) != RC_NOT_CONNECTED)
+                        if (GetCon(s, 0) != RC_NOT_CONNECTED)
                         {
                             int ax = x + GetDirOffsetX(0);
                             int ay = y + GetDirOffsetY(0);
-                            int ai = chf.cells[ax + ay * w].index + GetCon(ref s, 0);
+                            int ai = chf.cells[ax + ay * w].index + GetCon(s, 0);
                             if ((srcReg[ai] & RC_BORDER_REG) == 0 && chf.areas[i] == chf.areas[ai])
                             {
                                 previd = srcReg[ai];
@@ -1866,11 +1866,11 @@ namespace DotRecast.Recast
                         }
 
                         // -y
-                        if (GetCon(ref s, 3) != RC_NOT_CONNECTED)
+                        if (GetCon(s, 3) != RC_NOT_CONNECTED)
                         {
                             int ax = x + GetDirOffsetX(3);
                             int ay = y + GetDirOffsetY(3);
-                            int ai = chf.cells[ax + ay * w].index + GetCon(ref s, 3);
+                            int ai = chf.cells[ax + ay * w].index + GetCon(s, 3);
                             if (srcReg[ai] != 0 && (srcReg[ai] & RC_BORDER_REG) == 0 && chf.areas[i] == chf.areas[ai])
                             {
                                 int nr = srcReg[ai];


### PR DESCRIPTION
- Changed the `GetCon` method signature in `RcRecast` to accept `RcCompactSpan` using the `in` modifier instead of `ref`.
- This change improves semantic clarity by indicating that the span is read-only.
- Updated all usages across `RcAreas`, `RcContours`, `RcLayers`, `RcMeshDetails`, and `RcRegions` to match the new signature.