### PR TITLE
refactor: use 'in' modifier for struct parameters to avoid unnecessar…

### DIFF
--- a/src/DotRecast.Detour.TileCache/DtTileCache.cs
+++ b/src/DotRecast.Detour.TileCache/DtTileCache.cs
@@ -54,7 +54,7 @@ namespace DotRecast.Detour.TileCache
         private readonly List<DtObstacleRequest> m_reqs = new List<DtObstacleRequest>();
         private readonly List<long> m_update = new List<long>();
 
-        public DtTileCache(DtTileCacheParams option, DtTileCacheStorageParams storageParams, DtNavMesh navmesh, IRcCompressor tcomp, IDtTileCacheMeshProcess tmprocs)
+        public DtTileCache(in DtTileCacheParams option, DtTileCacheStorageParams storageParams, DtNavMesh navmesh, IRcCompressor tcomp, IDtTileCacheMeshProcess tmprocs)
         {
             m_params = option;
             m_storageParams = storageParams;

--- a/src/DotRecast.Detour.TileCache/Io/DtTileCacheWriter.cs
+++ b/src/DotRecast.Detour.TileCache/Io/DtTileCacheWriter.cs
@@ -69,7 +69,7 @@ namespace DotRecast.Detour.TileCache.Io
             }
         }
 
-        private void WriteCacheParams(BinaryWriter stream, DtTileCacheParams option, RcByteOrder order)
+        private void WriteCacheParams(BinaryWriter stream, in DtTileCacheParams option, RcByteOrder order)
         {
             RcIO.Write(stream, option.orig.X, order);
             RcIO.Write(stream, option.orig.Y, order);

--- a/src/DotRecast.Detour/DtNavMesh.cs
+++ b/src/DotRecast.Detour/DtNavMesh.cs
@@ -47,7 +47,7 @@ namespace DotRecast.Detour
         /** The maximum number of vertices per navigation polygon. */
         private int m_maxVertPerPoly;
 
-        public DtStatus Init(DtNavMeshParams param, int maxVertsPerPoly)
+        public DtStatus Init(in DtNavMeshParams param, int maxVertsPerPoly)
         {
             m_params = param;
             m_orig = param.orig;

--- a/src/DotRecast.Detour/Io/DtMeshSetReader.cs
+++ b/src/DotRecast.Detour/Io/DtMeshSetReader.cs
@@ -70,7 +70,7 @@ namespace DotRecast.Detour.Io
             bool cCompatibility = header.version == NavMeshSetHeader.NAVMESHSET_VERSION;
             DtNavMesh mesh = new DtNavMesh();
             mesh.Init(header.option, header.maxVertsPerPoly);
-            ReadTiles(bb, is32Bit, ref header, cCompatibility, mesh);
+            ReadTiles(bb, is32Bit, header, cCompatibility, mesh);
             return mesh;
         }
 
@@ -107,7 +107,7 @@ namespace DotRecast.Detour.Io
             return header;
         }
 
-        private void ReadTiles(RcByteBuffer bb, bool is32Bit, ref NavMeshSetHeader header, bool cCompatibility, DtNavMesh mesh)
+        private void ReadTiles(RcByteBuffer bb, bool is32Bit, in NavMeshSetHeader header, bool cCompatibility, DtNavMesh mesh)
         {
             // Read tiles.
             for (int i = 0; i < header.numTiles; ++i)
@@ -138,7 +138,7 @@ namespace DotRecast.Detour.Io
             }
         }
 
-        private long Convert32BitRef(int refs, DtNavMeshParams option)
+        private long Convert32BitRef(int refs, in DtNavMeshParams option)
         {
             int m_tileBits = DtUtils.Ilog2(DtUtils.NextPow2(option.maxTiles));
             int m_polyBits = DtUtils.Ilog2(DtUtils.NextPow2(option.maxPolys));

--- a/src/DotRecast.Detour/Io/DtNavMeshParamWriter.cs
+++ b/src/DotRecast.Detour/Io/DtNavMeshParamWriter.cs
@@ -5,7 +5,7 @@ namespace DotRecast.Detour.Io
 {
     public class DtNavMeshParamWriter
     {
-        public void Write(BinaryWriter stream, DtNavMeshParams option, RcByteOrder order)
+        public void Write(BinaryWriter stream, in DtNavMeshParams option, RcByteOrder order)
         {
             RcIO.Write(stream, option.orig.X, order);
             RcIO.Write(stream, option.orig.Y, order);


### PR DESCRIPTION
…y copying

- Update `DtNavMesh.Init` to accept `DtNavMeshParams` with `in` modifier.
- Update `DtTileCache` constructor to accept `DtTileCacheParams` with `in` modifier.
- Update `DtMeshSetReader` methods (`ReadTiles`, `Convert32BitRef`) to use `in` modifier for `NavMeshSetHeader` and `DtNavMeshParams`.
- Update `DtTileCacheWriter` and `DtNavMeshParamWriter` to use `in` modifier for params.

This change improves performance by passing these structs by reference.