### PR TITLE
Optimize Detour FindPath hot path and reduce query allocations

### DIFF
--- a/src/DotRecast.Core/Collections/RcSortedQueue.cs
+++ b/src/DotRecast.Core/Collections/RcSortedQueue.cs
@@ -25,6 +25,7 @@ namespace DotRecast.Core.Collections
 {
     public class RcSortedQueue<T>
     {
+        private bool _dirty;
         private readonly List<T> _items;
         private readonly Comparison<T> _comparison;
 
@@ -47,10 +48,32 @@ namespace DotRecast.Core.Collections
         public void Clear()
         {
             _items.Clear();
+            _dirty = false;
+        }
+
+        public void MarkDirty()
+        {
+            _dirty = true;
+        }
+
+        private void Balance()
+        {
+            if (!_dirty)
+            {
+                return;
+            }
+
+            for (int i = (_items.Count / 2) - 1; i >= 0; --i)
+            {
+                SiftDown(i);
+            }
+
+            _dirty = false;
         }
 
         public T Peek()
         {
+            Balance();
             return _items[0];
         }
 
@@ -76,7 +99,10 @@ namespace DotRecast.Core.Collections
                 return;
 
             _items.Add(item);
-            SiftUp(_items.Count - 1);
+            if (!_dirty)
+            {
+                SiftUp(_items.Count - 1);
+            }
         }
 
         public bool Remove(T item)
@@ -99,6 +125,11 @@ namespace DotRecast.Core.Collections
             _items.RemoveAt(lastIndex);
             _items[idx] = last;
 
+            if (_dirty)
+            {
+                return true;
+            }
+
             int parent = (idx - 1) / 2;
             if (0 < idx && IsHigherPriority(idx, parent))
             {
@@ -115,6 +146,7 @@ namespace DotRecast.Core.Collections
 
         public List<T> ToList()
         {
+            Balance();
             var temp = new List<T>(_items);
             temp.Sort(_comparison);
             return temp;

--- a/src/DotRecast.Core/Collections/RcSortedQueue.cs
+++ b/src/DotRecast.Core/Collections/RcSortedQueue.cs
@@ -25,14 +25,13 @@ namespace DotRecast.Core.Collections
 {
     public class RcSortedQueue<T>
     {
-        private bool _dirty;
         private readonly List<T> _items;
         private readonly Comparison<T> _comparison;
 
         public RcSortedQueue(Comparison<T> comp)
         {
             _items = new List<T>();
-            _comparison = (x, y) => comp(x, y) * -1;
+            _comparison = comp;
         }
 
         public int Count()
@@ -48,28 +47,26 @@ namespace DotRecast.Core.Collections
         public void Clear()
         {
             _items.Clear();
-            _dirty = false;
-        }
-
-        private void Balance()
-        {
-            if (_dirty)
-            {
-                _items.Sort(_comparison); // reverse
-                _dirty = false;
-            }
         }
 
         public T Peek()
         {
-            Balance();
-            return _items[^1];
+            return _items[0];
         }
 
         public T Dequeue()
         {
             var node = Peek();
-            _items.RemoveAt(_items.Count - 1);
+            int lastIndex = _items.Count - 1;
+            T last = _items[lastIndex];
+            _items.RemoveAt(lastIndex);
+
+            if (0 < _items.Count)
+            {
+                _items[0] = last;
+                SiftDown(0);
+            }
+
             return node;
         }
 
@@ -79,7 +76,7 @@ namespace DotRecast.Core.Collections
                 return;
 
             _items.Add(item);
-            _dirty = true;
+            SiftUp(_items.Count - 1);
         }
 
         public bool Remove(T item)
@@ -87,23 +84,88 @@ namespace DotRecast.Core.Collections
             if (null == item)
                 return false;
 
-            //int idx = _items.BinarySearch(item, _comparer); // don't use this! Because reference types can be reused externally.
-            //int idx = _items.FindLastIndex(x => item.Equals(x));
             int idx = _items.LastIndexOf(item);
             if (0 > idx)
                 return false;
 
-            _items.RemoveAt(idx);
+            int lastIndex = _items.Count - 1;
+            if (idx == lastIndex)
+            {
+                _items.RemoveAt(lastIndex);
+                return true;
+            }
+
+            T last = _items[lastIndex];
+            _items.RemoveAt(lastIndex);
+            _items[idx] = last;
+
+            int parent = (idx - 1) / 2;
+            if (0 < idx && IsHigherPriority(idx, parent))
+            {
+                SiftUp(idx);
+            }
+            else
+            {
+                SiftDown(idx);
+            }
+
             return true;
         }
 
 
         public List<T> ToList()
         {
-            Balance();
             var temp = new List<T>(_items);
-            temp.Reverse();
+            temp.Sort(_comparison);
             return temp;
+        }
+
+        private bool IsHigherPriority(int index, int parentIndex)
+        {
+            return 0 > _comparison(_items[index], _items[parentIndex]);
+        }
+
+        private void SiftUp(int index)
+        {
+            while (0 < index)
+            {
+                int parent = (index - 1) / 2;
+                if (!IsHigherPriority(index, parent))
+                {
+                    break;
+                }
+
+                (_items[index], _items[parent]) = (_items[parent], _items[index]);
+                index = parent;
+            }
+        }
+
+        private void SiftDown(int index)
+        {
+            int count = _items.Count;
+            while (true)
+            {
+                int left = (index * 2) + 1;
+                if (left >= count)
+                {
+                    break;
+                }
+
+                int right = left + 1;
+                int best = left;
+                if (right < count && 0 > _comparison(_items[right], _items[left]))
+                {
+                    best = right;
+                }
+
+                if (0 >= _comparison(_items[index], _items[best]))
+                {
+                    break;
+                }
+
+                (_items[index], _items[best]) = (_items[best], _items[index]);
+                index = best;
+            }
         }
     }
 }

--- a/src/DotRecast.Detour/DtFindNearestPolyQuery.cs
+++ b/src/DotRecast.Detour/DtFindNearestPolyQuery.cs
@@ -29,25 +29,29 @@ namespace DotRecast.Detour
 
         public void Process(DtMeshTile tile, ReadOnlySpan<int> polys, ReadOnlySpan<long> refs, int count)
         {
+            float walkableClimb = tile.data.header.walkableClimb;
+
             for (int i = 0; i < count; ++i)
             {
                 long polyRef = refs[i];
                 float d;
-                
+
                 // Find nearest polygon amongst the nearby polygons.
-                _query.ClosestPointOnPoly(polyRef, _center, out var closestPtPoly, out var posOverPoly);
+                _query.ClosestPointOnPolyUnsafe(tile, tile.data.polys[polys[i]], _center, out var closestPtPoly, out var posOverPoly);
 
                 // If a point is directly over a polygon and closer than
                 // climb height, favor that instead of straight line nearest point.
-                RcVec3f diff = RcVec3f.Subtract(_center, closestPtPoly);
+                float dx = _center.X - closestPtPoly.X;
+                float dy = _center.Y - closestPtPoly.Y;
+                float dz = _center.Z - closestPtPoly.Z;
                 if (posOverPoly)
                 {
-                    d = MathF.Abs(diff.Y) - tile.data.header.walkableClimb;
+                    d = MathF.Abs(dy) - walkableClimb;
                     d = d > 0 ? d * d : 0;
                 }
                 else
                 {
-                    d = diff.LengthSquared();
+                    d = dx * dx + dy * dy + dz * dz;
                 }
 
                 if (d < _nearestDistanceSqr)

--- a/src/DotRecast.Detour/DtFindNearestPolyQuery.cs
+++ b/src/DotRecast.Detour/DtFindNearestPolyQuery.cs
@@ -6,7 +6,7 @@ namespace DotRecast.Detour
     public class DtFindNearestPolyQuery : IDtPolyQuery
     {
         private readonly DtNavMeshQuery _query;
-        private readonly RcVec3f _center;
+        private RcVec3f _center;
         private float _nearestDistanceSqr;
         private long _nearestRef;
         private RcVec3f _nearestPoint;
@@ -15,9 +15,16 @@ namespace DotRecast.Detour
         public DtFindNearestPolyQuery(DtNavMeshQuery query, RcVec3f center)
         {
             _query = query;
+            Reset(center);
+        }
+
+        public void Reset(RcVec3f center)
+        {
             _center = center;
             _nearestDistanceSqr = float.MaxValue;
+            _nearestRef = 0;
             _nearestPoint = center;
+            _overPoly = false;
         }
 
         public void Process(DtMeshTile tile, ReadOnlySpan<int> polys, ReadOnlySpan<long> refs, int count)

--- a/src/DotRecast.Detour/DtNavMesh.cs
+++ b/src/DotRecast.Detour/DtNavMesh.cs
@@ -1229,6 +1229,11 @@ namespace DotRecast.Detour
         public void ClosestPointOnPoly(long refs, RcVec3f pos, out RcVec3f closest, out bool posOverPoly)
         {
             GetTileAndPolyByRefUnsafe(refs, out var tile, out var poly);
+            ClosestPointOnPoly(tile, poly, pos, out closest, out posOverPoly);
+        }
+
+        public void ClosestPointOnPoly(DtMeshTile tile, DtPoly poly, RcVec3f pos, out RcVec3f closest, out bool posOverPoly)
+        {
             closest = pos;
 
             if (GetPolyHeight(tile, poly, pos, out var h))

--- a/src/DotRecast.Detour/DtNavMeshQuery.cs
+++ b/src/DotRecast.Detour/DtNavMeshQuery.cs
@@ -40,6 +40,7 @@ namespace DotRecast.Detour
         protected readonly DtNodePool m_tinyNodePool; //< Pointer to small node pool. 
         protected readonly DtNodePool m_nodePool; //< Pointer to node pool. 
         protected readonly DtNodeQueue m_openList; //< Pointer to open list queue. 
+        protected readonly DtFindNearestPolyQuery m_findNearestPolyQuery;
 
         //////////////////////////////////////////////////////////////////////////////////////////
 
@@ -64,6 +65,7 @@ namespace DotRecast.Detour
             m_nodePool = new DtNodePool();
             m_openList = new DtNodeQueue();
             m_tinyNodePool = new DtNodePool();
+            m_findNearestPolyQuery = new DtFindNearestPolyQuery(this, RcVec3f.Zero);
         }
 
         /// Returns random location on navmesh.
@@ -586,16 +588,16 @@ namespace DotRecast.Detour
             isOverPoly = false;
 
             // Get nearby polygons from proximity grid.
-            DtFindNearestPolyQuery query = new DtFindNearestPolyQuery(this, center);
-            DtStatus status = QueryPolygons(center, halfExtents, filter, query);
+            m_findNearestPolyQuery.Reset(center);
+            DtStatus status = QueryPolygons(center, halfExtents, filter, m_findNearestPolyQuery);
             if (status.Failed())
             {
                 return status;
             }
 
-            nearestRef = query.NearestRef();
-            nearestPt = query.NearestPt();
-            isOverPoly = query.OverPoly();
+            nearestRef = m_findNearestPolyQuery.NearestRef();
+            nearestPt = m_findNearestPolyQuery.NearestPt();
+            isOverPoly = m_findNearestPolyQuery.OverPoly();
 
             return DtStatus.DT_SUCCESS;
         }

--- a/src/DotRecast.Detour/DtNavMeshQuery.cs
+++ b/src/DotRecast.Detour/DtNavMeshQuery.cs
@@ -866,6 +866,8 @@ namespace DotRecast.Detour
                 return DtStatus.DT_SUCCESS;
             }
 
+            DtQueryDefaultFilter defaultFilter = filter as DtQueryDefaultFilter;
+
             m_nodePool.Clear();
             m_openList.Clear();
 
@@ -930,7 +932,14 @@ namespace DotRecast.Detour
                     // The API input has been checked already, skip checking internal data.
                     m_nav.GetTileAndPolyByRefUnsafe(neighbourRef, out var neighbourTile, out var neighbourPoly);
 
-                    if (!filter.PassFilter(neighbourRef, neighbourTile, neighbourPoly))
+                    if (null != defaultFilter)
+                    {
+                        if (!defaultFilter.PassFilter(neighbourPoly.flags))
+                        {
+                            continue;
+                        }
+                    }
+                    else if (!filter.PassFilter(neighbourRef, neighbourTile, neighbourPoly))
                     {
                         continue;
                     }
@@ -964,14 +973,25 @@ namespace DotRecast.Detour
                     if (neighbourRef == endRef)
                     {
                         // Cost
-                        float curCost = filter.GetCost(bestNode.pos, neighbourNode.pos,
-                            parentRef, parentTile, parentPoly,
-                            bestRef, bestTile, bestPoly,
-                            neighbourRef, neighbourTile, neighbourPoly);
-                        float endCost = filter.GetCost(neighbourNode.pos, endPos,
-                            bestRef, bestTile, bestPoly,
-                            neighbourRef, neighbourTile, neighbourPoly,
-                            0, null, null);
+                        float curCost;
+                        float endCost;
+                        if (null != defaultFilter)
+                        {
+                            float areaCost = defaultFilter.GetAreaCost(neighbourPoly.GetArea());
+                            curCost = RcVec3f.Distance(bestNode.pos, neighbourNode.pos) * areaCost;
+                            endCost = RcVec3f.Distance(neighbourNode.pos, endPos) * areaCost;
+                        }
+                        else
+                        {
+                            curCost = filter.GetCost(bestNode.pos, neighbourNode.pos,
+                                parentRef, parentTile, parentPoly,
+                                bestRef, bestTile, bestPoly,
+                                neighbourRef, neighbourTile, neighbourPoly);
+                            endCost = filter.GetCost(neighbourNode.pos, endPos,
+                                bestRef, bestTile, bestPoly,
+                                neighbourRef, neighbourTile, neighbourPoly,
+                                0, null, null);
+                        }
 
                         cost = bestNode.cost + curCost + endCost;
                         heuristic = 0;
@@ -979,10 +999,19 @@ namespace DotRecast.Detour
                     else
                     {
                         // Cost
-                        float curCost = filter.GetCost(bestNode.pos, neighbourNode.pos,
-                            parentRef, parentTile, parentPoly,
-                            bestRef, bestTile, bestPoly,
-                            neighbourRef, neighbourTile, neighbourPoly);
+                        float curCost;
+                        if (null != defaultFilter)
+                        {
+                            curCost = RcVec3f.Distance(bestNode.pos, neighbourNode.pos) * defaultFilter.GetAreaCost(neighbourPoly.GetArea());
+                        }
+                        else
+                        {
+                            curCost = filter.GetCost(bestNode.pos, neighbourNode.pos,
+                                parentRef, parentTile, parentPoly,
+                                bestRef, bestTile, bestPoly,
+                                neighbourRef, neighbourTile, neighbourPoly);
+                        }
+
                         cost = bestNode.cost + curCost;
                         heuristic = RcVec3f.Distance(neighbourNode.pos, endPos) * DtDefaultQueryHeuristic.H_SCALE;
                     }
@@ -1131,6 +1160,7 @@ namespace DotRecast.Detour
 
             var rayHit = new DtRaycastHit();
             rayHit.maxPath = 0;
+            DtQueryDefaultFilter defaultFilter = m_query.filter as DtQueryDefaultFilter;
 
             int iter = 0;
             while (iter < maxIter && !m_openList.IsEmpty())
@@ -1216,7 +1246,14 @@ namespace DotRecast.Detour
                     // The API input has been checked already, skip checking internal data.
                     m_nav.GetTileAndPolyByRefUnsafe(neighbourRef, out var neighbourTile, out var neighbourPoly);
 
-                    if (!m_query.filter.PassFilter(neighbourRef, neighbourTile, neighbourPoly))
+                    if (null != defaultFilter)
+                    {
+                        if (!defaultFilter.PassFilter(neighbourPoly.flags))
+                        {
+                            continue;
+                        }
+                    }
+                    else if (!m_query.filter.PassFilter(neighbourRef, neighbourTile, neighbourPoly))
                     {
                         continue;
                     }
@@ -1266,20 +1303,37 @@ namespace DotRecast.Detour
                     else
                     {
                         // No shortcut found.
-                        float curCost = m_query.filter.GetCost(bestNode.pos, neighbourNode.pos,
-                            parentRef, parentTile, parentPoly,
-                            bestRef, bestTile, bestPoly,
-                            neighbourRef, neighbourTile, neighbourPoly);
+                        float curCost;
+                        if (null != defaultFilter)
+                        {
+                            curCost = RcVec3f.Distance(bestNode.pos, neighbourNode.pos) * defaultFilter.GetAreaCost(neighbourPoly.GetArea());
+                        }
+                        else
+                        {
+                            curCost = m_query.filter.GetCost(bestNode.pos, neighbourNode.pos,
+                                parentRef, parentTile, parentPoly,
+                                bestRef, bestTile, bestPoly,
+                                neighbourRef, neighbourTile, neighbourPoly);
+                        }
+
                         cost = bestNode.cost + curCost;
                     }
 
                     // Special case for last node.
                     if (neighbourRef == m_query.endRef)
                     {
-                        float endCost = m_query.filter.GetCost(neighbourNode.pos, m_query.endPos,
-                            bestRef, bestTile, bestPoly,
-                            neighbourRef, neighbourTile, neighbourPoly,
-                            0, null, null);
+                        float endCost;
+                        if (null != defaultFilter)
+                        {
+                            endCost = RcVec3f.Distance(neighbourNode.pos, m_query.endPos) * defaultFilter.GetAreaCost(neighbourPoly.GetArea());
+                        }
+                        else
+                        {
+                            endCost = m_query.filter.GetCost(neighbourNode.pos, m_query.endPos,
+                                bestRef, bestTile, bestPoly,
+                                neighbourRef, neighbourTile, neighbourPoly,
+                                0, null, null);
+                        }
 
                         cost = cost + endCost;
                         heuristic = 0;
@@ -1697,6 +1751,7 @@ namespace DotRecast.Detour
 
             if (pathSize > 1)
             {
+                bool appendCrossings = (options & (DtStraightPathOptions.DT_STRAIGHTPATH_AREA_CROSSINGS | DtStraightPathOptions.DT_STRAIGHTPATH_ALL_CROSSINGS)) != 0;
                 RcVec3f portalApex = closestStartPos;
                 RcVec3f portalLeft = portalApex;
                 RcVec3f portalRight = portalApex;
@@ -1733,7 +1788,7 @@ namespace DotRecast.Detour
                             }
 
                             // Append portals along the current straight path segment.
-                            if ((options & (DtStraightPathOptions.DT_STRAIGHTPATH_AREA_CROSSINGS | DtStraightPathOptions.DT_STRAIGHTPATH_ALL_CROSSINGS)) != 0)
+                            if (appendCrossings)
                             {
                                 // Ignore status return value as we're just about to return anyway.
                                 AppendPortals(apexIndex, i, closestEndPos, path, straightPath, ref straightPathCount, maxStraightPath, options);
@@ -1776,7 +1831,7 @@ namespace DotRecast.Detour
                         else
                         {
                             // Append portals along the current straight path segment.
-                            if ((options & (DtStraightPathOptions.DT_STRAIGHTPATH_AREA_CROSSINGS | DtStraightPathOptions.DT_STRAIGHTPATH_ALL_CROSSINGS)) != 0)
+                            if (appendCrossings)
                             {
                                 stat = AppendPortals(apexIndex, leftIndex, portalLeft, path, straightPath, ref straightPathCount, maxStraightPath, options);
                                 if (!stat.InProgress())
@@ -1832,7 +1887,7 @@ namespace DotRecast.Detour
                         else
                         {
                             // Append portals along the current straight path segment.
-                            if ((options & (DtStraightPathOptions.DT_STRAIGHTPATH_AREA_CROSSINGS | DtStraightPathOptions.DT_STRAIGHTPATH_ALL_CROSSINGS)) != 0)
+                            if (appendCrossings)
                             {
                                 stat = AppendPortals(apexIndex, rightIndex, portalRight, path, straightPath, ref straightPathCount, maxStraightPath, options);
                                 if (!stat.InProgress())
@@ -1877,7 +1932,7 @@ namespace DotRecast.Detour
                 }
 
                 // Append portals along the current straight path segment.
-                if ((options & (DtStraightPathOptions.DT_STRAIGHTPATH_AREA_CROSSINGS | DtStraightPathOptions.DT_STRAIGHTPATH_ALL_CROSSINGS)) != 0)
+                if (appendCrossings)
                 {
                     stat = AppendPortals(apexIndex, pathSize - 1, closestEndPos, path, straightPath, ref straightPathCount, maxStraightPath, options);
                     if (!stat.InProgress())

--- a/src/DotRecast.Detour/DtNavMeshQuery.cs
+++ b/src/DotRecast.Detour/DtNavMeshQuery.cs
@@ -454,6 +454,11 @@ namespace DotRecast.Detour
             return DtStatus.DT_SUCCESS;
         }
 
+        internal void ClosestPointOnPolyUnsafe(DtMeshTile tile, DtPoly poly, RcVec3f pos, out RcVec3f closest, out bool posOverPoly)
+        {
+            m_nav.ClosestPointOnPoly(tile, poly, pos, out closest, out posOverPoly);
+        }
+
         /// @par
         ///
         /// Much faster than ClosestPointOnPoly().

--- a/src/DotRecast.Detour/DtNodePool.cs
+++ b/src/DotRecast.Detour/DtNodePool.cs
@@ -25,20 +25,31 @@ namespace DotRecast.Detour
 {
     public class DtNodePool
     {
-        private readonly Dictionary<long, List<DtNode>> m_map;
+        private readonly Dictionary<long, NodeBucket> m_map;
+        private readonly Stack<NodeBucket> m_bucketPool;
+        private readonly List<DtNode> m_findNodesBuffer;
 
         private int m_nodeCount;
         private readonly List<DtNode> m_nodes;
 
         public DtNodePool()
         {
-            m_map = new Dictionary<long, List<DtNode>>();
+            m_map = new Dictionary<long, NodeBucket>();
+            m_bucketPool = new Stack<NodeBucket>();
+            m_findNodesBuffer = new List<DtNode>(4);
             m_nodes = new List<DtNode>();
         }
 
         public void Clear()
         {
+            foreach (NodeBucket bucket in m_map.Values)
+            {
+                bucket.Reset();
+                m_bucketPool.Push(bucket);
+            }
+
             m_map.Clear();
+            m_findNodesBuffer.Clear();
             m_nodeCount = 0;
         }
 
@@ -49,21 +60,23 @@ namespace DotRecast.Detour
 
         public int FindNodes(long id, out List<DtNode> nodes)
         {
-            var hasNode = m_map.TryGetValue(id, out nodes);
-            if (hasNode)
+            if (m_map.TryGetValue(id, out var bucket))
             {
-                return nodes.Count;
+                m_findNodesBuffer.Clear();
+                bucket.CopyTo(m_findNodesBuffer);
+                nodes = m_findNodesBuffer;
+                return m_findNodesBuffer.Count;
             }
 
+            nodes = null;
             return 0;
         }
 
         public DtNode FindNode(long id)
         {
-            m_map.TryGetValue(id, out var nodes);
-            if (nodes != null && 0 != nodes.Count)
+            if (m_map.TryGetValue(id, out var bucket))
             {
-                return nodes[0];
+                return bucket.FindAny();
             }
 
             return null;
@@ -71,27 +84,25 @@ namespace DotRecast.Detour
 
         public DtNode GetNode(long id, int state)
         {
-            m_map.TryGetValue(id, out var nodes);
-            if (nodes != null)
+            m_map.TryGetValue(id, out var bucket);
+            if (bucket == null)
             {
-                foreach (DtNode node in nodes)
-                {
-                    if (node.state == state)
-                    {
-                        return node;
-                    }
-                }
-            }
-            else
-            {
-                nodes = new List<DtNode>();
-                m_map.Add(id, nodes);
+                bucket = RentBucket();
+                m_map.Add(id, bucket);
             }
 
-            return Create(id, state, nodes);
+            DtNode node = bucket.Find(state);
+            if (node != null)
+            {
+                return node;
+            }
+
+            node = Create(id, state);
+            bucket.Add(state, node);
+            return node;
         }
 
-        private DtNode Create(long id, int state, List<DtNode> nodes)
+        private DtNode Create(long id, int state)
         {
             if (m_nodes.Count <= m_nodeCount)
             {
@@ -108,8 +119,6 @@ namespace DotRecast.Detour
             node.id = id;
             node.state = state;
             node.flags = 0;
-
-            nodes.Add(node);
             return node;
         }
 
@@ -135,6 +144,115 @@ namespace DotRecast.Detour
         public IEnumerable<DtNode> AsEnumerable()
         {
             return m_nodes.Take(m_nodeCount);
+        }
+
+        private NodeBucket RentBucket()
+        {
+            if (0 < m_bucketPool.Count)
+            {
+                return m_bucketPool.Pop();
+            }
+
+            return new NodeBucket();
+        }
+
+        private sealed class NodeBucket
+        {
+            private DtNode _node0;
+            private DtNode _node1;
+            private DtNode _node2;
+            private DtNode _node3;
+            private List<DtNode> _overflow;
+            private int _count;
+
+            public void Reset()
+            {
+                _node0 = null;
+                _node1 = null;
+                _node2 = null;
+                _node3 = null;
+                _overflow?.Clear();
+                _count = 0;
+            }
+
+            public DtNode Find(int state)
+            {
+                if (null != _node0 && _node0.state == state) return _node0;
+                if (null != _node1 && _node1.state == state) return _node1;
+                if (null != _node2 && _node2.state == state) return _node2;
+                if (null != _node3 && _node3.state == state) return _node3;
+
+                if (_overflow == null)
+                {
+                    return null;
+                }
+
+                for (int i = 0; i < _overflow.Count; ++i)
+                {
+                    DtNode node = _overflow[i];
+                    if (node.state == state)
+                    {
+                        return node;
+                    }
+                }
+
+                return null;
+            }
+
+            public void Add(int state, DtNode node)
+            {
+                if (null == node)
+                    return;
+
+                if (_node0 == null)
+                {
+                    _node0 = node;
+                }
+                else if (_node1 == null)
+                {
+                    _node1 = node;
+                }
+                else if (_node2 == null)
+                {
+                    _node2 = node;
+                }
+                else if (_node3 == null)
+                {
+                    _node3 = node;
+                }
+                else
+                {
+                    _overflow ??= new List<DtNode>(4);
+                    _overflow.Add(node);
+                }
+
+                _count++;
+            }
+
+            public DtNode FindAny()
+            {
+                if (_node0 != null) return _node0;
+                if (_node1 != null) return _node1;
+                if (_node2 != null) return _node2;
+                if (_node3 != null) return _node3;
+                if (_overflow != null && 0 < _overflow.Count) return _overflow[0];
+                return null;
+            }
+
+            public void CopyTo(List<DtNode> dst)
+            {
+                if (_count == 0)
+                    return;
+
+                if (_node0 != null) dst.Add(_node0);
+                if (_node1 != null) dst.Add(_node1);
+                if (_node2 != null) dst.Add(_node2);
+                if (_node3 != null) dst.Add(_node3);
+                if (_overflow != null)
+                {
+                    dst.AddRange(_overflow);
+                }
+            }
         }
     }
 }

--- a/src/DotRecast.Detour/DtNodeQueue.cs
+++ b/src/DotRecast.Detour/DtNodeQueue.cs
@@ -58,6 +58,7 @@ namespace DotRecast.Detour
 
         public void Modify(DtNode node)
         {
+            m_heap.MarkDirty();
             m_heap.Remove(node);
             Push(node);
         }

--- a/src/DotRecast.Detour/DtQueryDefaultFilter.cs
+++ b/src/DotRecast.Detour/DtQueryDefaultFilter.cs
@@ -19,6 +19,7 @@ freely, subject to the following restrictions:
 */
 
 using System;
+using System.Runtime.CompilerServices;
 using DotRecast.Core.Numerics;
 
 namespace DotRecast.Detour
@@ -81,15 +82,29 @@ namespace DotRecast.Detour
             }
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public bool PassFilter(long refs, DtMeshTile tile, DtPoly poly)
         {
             return (poly.flags & m_includeFlags) != 0 && (poly.flags & m_excludeFlags) == 0;
         }
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public float GetCost(RcVec3f pa, RcVec3f pb, long prevRef, DtMeshTile prevTile, DtPoly prevPoly, long curRef,
             DtMeshTile curTile, DtPoly curPoly, long nextRef, DtMeshTile nextTile, DtPoly nextPoly)
         {
             return RcVec3f.Distance(pa, pb) * m_areaCost[curPoly.GetArea()];
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public bool PassFilter(int polyFlags)
+        {
+            return (polyFlags & m_includeFlags) != 0 && (polyFlags & m_excludeFlags) == 0;
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public float GetAreaCost(int area)
+        {
+            return m_areaCost[area];
         }
 
         public int GetIncludeFlags()


### PR DESCRIPTION
﻿## Summary
This PR targets `DtNavMeshQuery.FindPath` hot-path cost and unnecessary allocations in Detour query internals.

### Main changes
- Replace full-sort queue behavior in `RcSortedQueue<T>` with heap operations (`SiftUp/SiftDown`) and add deferred re-heap support for mutable-priority updates.
- Keep `DtNodeQueue.Modify(...)` semantics correct when `DtNode.total` is changed externally (`MarkDirty()` + re-balance).
- Refactor `DtNodePool` per-ref storage to reduce hot-path dictionary/list overhead and improve node/bucket reuse.
- Reuse `DtFindNearestPolyQuery` instance in `DtNavMeshQuery` and add `Reset(...)` to avoid per-call allocations in `FindNearestPoly`.

## Why
In upstream behavior, `FindPath` spent substantial time in open-list and node-pool operations under high query volume. Also, `FindNearestPoly` allocated a query helper object on every call.

## Validation
- `dotnet test test/DotRecast.Detour.Test/DotRecast.Detour.Test.csproj -c Release -f net10.0`

## External benchmark note
Using a separate .NET BenchmarkDotNet harness (same machine, Windows, .NET 10), DotRecast-side `FindPath` path phases improved significantly vs prior baseline and moved to zero managed allocations in core split-path benchmarks.
