### PR TITLE
Make `DtNodePool` allocation-free via node chaining

### DIFF
--- a/src/DotRecast.Detour/DtNavMeshQuery.cs
+++ b/src/DotRecast.Detour/DtNavMeshQuery.cs
@@ -3758,12 +3758,12 @@ namespace DotRecast.Detour
             }
 
             if (m_nodePool.FindNodes(endRef, out var endNodes) != 1
-                || (endNodes[0].flags & DtNodeFlags.DT_NODE_CLOSED) == 0)
+                || (endNodes.flags & DtNodeFlags.DT_NODE_CLOSED) == 0)
             {
                 return DtStatus.DT_FAILURE | DtStatus.DT_INVALID_PARAM;
             }
 
-            DtNode endNode = endNodes[0];
+            DtNode endNode = endNodes;
 
             return GetPathToNode(endNode, path, out pathCount, maxPath);
         }
@@ -3821,10 +3821,10 @@ namespace DotRecast.Detour
                 return false;
             }
 
-            int n = m_nodePool.FindNodes(refs, out var nodes);
-            for (int i = 0; i < n; ++i)
+            m_nodePool.FindNodes(refs, out var nodes);
+            for (DtNode node = nodes; node != null; node = node.next)
             {
-                if ((nodes[i].flags & DtNodeFlags.DT_NODE_CLOSED) != 0)
+                if ((node.flags & DtNodeFlags.DT_NODE_CLOSED) != 0)
                 {
                     return true;
                 }

--- a/src/DotRecast.Detour/DtNode.cs
+++ b/src/DotRecast.Detour/DtNode.cs
@@ -35,6 +35,10 @@ namespace DotRecast.Detour
         public int flags; // Node flags. A combination of dtNodeFlags.
         public long id; // Polygon ref the node corresponds to.
 
+        // intrusive same-poly-ref chain owned by DtNodePool, replacing
+        // the upstream per-ref List<DtNode> that allocated once per visited poly on every query.
+        public DtNode next;
+
         public DtNode(int ptr)
         {
             this.ptr = ptr;

--- a/src/DotRecast.Detour/DtNodePool.cs
+++ b/src/DotRecast.Detour/DtNodePool.cs
@@ -25,14 +25,14 @@ namespace DotRecast.Detour
 {
     public class DtNodePool
     {
-        private readonly Dictionary<long, List<DtNode>> m_map;
+        private readonly Dictionary<long, DtNode> m_map;
 
         private int m_nodeCount;
         private readonly List<DtNode> m_nodes;
 
         public DtNodePool()
         {
-            m_map = new Dictionary<long, List<DtNode>>();
+            m_map = new Dictionary<long, DtNode>();
             m_nodes = new List<DtNode>();
         }
 
@@ -47,51 +47,44 @@ namespace DotRecast.Detour
             return m_nodeCount;
         }
 
-        public int FindNodes(long id, out List<DtNode> nodes)
+        public int FindNodes(long id, out DtNode nodes)
         {
-            var hasNode = m_map.TryGetValue(id, out nodes);
-            if (hasNode)
+            m_map.TryGetValue(id, out nodes);
+            int count = 0;
+            for (DtNode node = nodes; node != null; node = node.next)
             {
-                return nodes.Count;
+                count++;
             }
 
-            return 0;
+            return count;
         }
 
         public DtNode FindNode(long id)
         {
-            m_map.TryGetValue(id, out var nodes);
-            if (nodes != null && 0 != nodes.Count)
-            {
-                return nodes[0];
-            }
-
-            return null;
+            m_map.TryGetValue(id, out var node);
+            return node;
         }
 
         public DtNode GetNode(long id, int state)
         {
-            m_map.TryGetValue(id, out var nodes);
-            if (nodes != null)
+            DtNode tail = null;
+            if (m_map.TryGetValue(id, out var node))
             {
-                foreach (DtNode node in nodes)
+                for (; node != null; node = node.next)
                 {
                     if (node.state == state)
                     {
                         return node;
                     }
+
+                    tail = node;
                 }
             }
-            else
-            {
-                nodes = new List<DtNode>();
-                m_map.Add(id, nodes);
-            }
 
-            return Create(id, state, nodes);
+            return Create(id, state, tail);
         }
 
-        private DtNode Create(long id, int state, List<DtNode> nodes)
+        private DtNode Create(long id, int state, DtNode tail)
         {
             if (m_nodes.Count <= m_nodeCount)
             {
@@ -108,8 +101,17 @@ namespace DotRecast.Detour
             node.id = id;
             node.state = state;
             node.flags = 0;
+            node.next = null;   // pooled instance may carry a stale chain from the previous query
 
-            nodes.Add(node);
+            if (tail != null)
+            {
+                tail.next = node;
+            }
+            else
+            {
+                m_map[id] = node;
+            }
+
             return node;
         }
 

--- a/test/DotRecast.Detour.Test/DtNodePoolTest.cs
+++ b/test/DotRecast.Detour.Test/DtNodePoolTest.cs
@@ -58,13 +58,20 @@ public class DtNodePoolTest
             var count = counts[i];
             var n = pool.FindNodes(i, out var nodes);
             Assert.That(n, Is.EqualTo(count));
-            Assert.That(nodes, Has.Count.EqualTo(count));
+
+            int chainLength = 0;
+            for (var chainNode = nodes; chainNode != null; chainNode = chainNode.next)
+            {
+                chainLength++;
+            }
+
+            Assert.That(chainLength, Is.EqualTo(count));
 
             var node = pool.FindNode(i);
-            Assert.That(nodes[0], Is.SameAs(node));
+            Assert.That(nodes, Is.SameAs(node));
 
             var node2 = pool.FindNode(i);
-            Assert.That(nodes[0], Is.SameAs(node2));
+            Assert.That(nodes, Is.SameAs(node2));
         }
 
         // check other count


### PR DESCRIPTION
Hello

I've been using DotRecast vibe-coding a game for fun. I have very limited experience with game development (web dev/mobile app background), but Mr Claude has "found" an opportunity for a performance optimization.

How genuine this is, I don't really know. I am not experienced enough to actually determine if this is correct or if it will break other parts of the package. If it's garbage, I apologize and you can just close it. I've had it benchmarked (A/B tested) and I made sure tests pass with and without my modifications - I of course had to modify one test.

If you're interested, please review carefully.
Edit: Naturally, I tested it as well as I can, and it works in my game (so far).

---
AI generated from here on out:

## Problem

`DtNodePool` keys nodes by poly ref through `Dictionary<long, List<DtNode>>`. `Clear()`
empties the map, so every query that visits N distinct polygons allocates N fresh
`List<DtNode>` instances in `GetNode()`:

```csharp
else
{
    nodes = new List<DtNode>();
    m_map.Add(id, nodes);
}
```

All of them become garbage at the next `Clear()`. The `DtNode` objects themselves are
correctly pooled via `m_nodes`; only the per-ref lists churn. Native recastnavigation has no
equivalent cost — its `dtNodePool` chains same-ref nodes through index arrays
(`m_first`/`m_next`) and allocates nothing per query.

For a game server issuing pathfinding queries every tick this shows up as steady GC pressure,
and worst-case latency jitter when collections land inside a query.

## Measurements

Workload: 107 real queries from our game (wander destinations that snap onto walkable but
disconnected islands, so the A* explores until its iteration budget is exhausted — the
worst case for node-pool churn), replayed 20× = 2,140 queries per configuration.
`InitSlicedFindPath` with `DT_FINDPATH_ANY_ANGLE`, budgets of 512 and 4096 iterations.
Unity 6000.5 Mono, Apple Silicon (M-series), single warmed `DtNavMeshQuery`.

Replacing the per-ref `List<DtNode>` with an intrusive `DtNode.next` chain
(node groups walk the chain; `DT_MAX_STATES_PER_NODE` semantics, node ordering, and the
public API are unchanged apart from `FindNodes` returning the chain head):

| 2,140 queries | upstream `master` (c9749304) | this PR |
|---|---|---|
| 512-iter budget: mean / worst | 0.638 ms / 3.51 ms | 0.584 ms / 1.32 ms |
| 512-iter budget: heap allocated | 136.6 MB (~65 KB/query) | 0 |
| 4096-iter budget: mean / worst | 8.169 ms / 17.32 ms | 7.737 ms / 14.13 ms |
| 4096-iter budget: GC collections during run | 7× gen0 + 7× gen1 | 0 |
| 4096-iter budget: heap allocated | 43.4 MB | 0 |

Mean time improves ~5–8%; the larger effect is the elimination of allocation (and with it
the worst-case jitter — the 3.51 ms vs 1.32 ms worst case at the small budget is GC noise,
not search work).

## Related observation (can file separately if useful)

Native `dtNavMeshQuery::init(nav, maxNodes)` bounds the node pool per query; the port's
`DtNavMeshQuery(nav)` has no equivalent, so a search toward an unreachable destination
expands until it has exhausted every reachable polygon (26,622 polys / ~95 ms / ~26k list
allocations per query on our mesh before we bounded iterations at the call site via
`UpdateSlicedFindPath(maxIter)`). A constructor-level `maxNodes` like native would restore
that guardrail for `FindPath` users who never touch the sliced API.